### PR TITLE
Align terminology: HarnessConfig → AgentConfig

### DIFF
--- a/spec/01-vision-and-goals.md
+++ b/spec/01-vision-and-goals.md
@@ -6,12 +6,12 @@
 
 Build a Kubernetes-native platform that orchestrates fleets of AI agents in stateful, isolated sandboxes. The platform treats agents as a first-class workload type — similar to how Kubernetes treats containers — providing primitives for lifecycle management, scheduling, observability, and coordination.
 
-The system is **agent-agnostic**: it does not embed any specific coding agent. Instead, it provides a universal harness interface that adapts to any agent runtime (Claude Code, Codex, Pi, Aider, etc.), allowing operators to choose — or mix — agents based on the task at hand.
+The system is **agent-agnostic**: it does not embed any specific coding agent. Instead, it provides a universal adapter interface (via the [Sandbox Agent SDK](https://sandboxagent.dev/)) that supports any coding harness (Claude Code, Codex, Pi, Aider, etc.), allowing operators to choose — or mix — agents based on the task at hand.
 
 ## Goals
 
 ### G1: Universal Agent Runtime
-Support multiple coding agent harnesses through a common adapter interface. Operators should be able to swap agents without changing their orchestration logic. Initially target: Claude Code, Codex, and Pi.
+Support multiple coding harnesses through a common adapter interface. Operators should be able to swap agents without changing their orchestration logic. Initially target: Claude Code, Codex, and Pi.
 
 ### G2: Stateful Sandboxes
 Provide persistent, isolated execution environments where agents can work across sessions without re-cloning repositories or reinstalling dependencies. Sandbox state (filesystem, installed packages, running processes) survives agent restarts and can be snapshotted/restored.

--- a/spec/02-concepts-and-terminology.md
+++ b/spec/02-concepts-and-terminology.md
@@ -9,10 +9,13 @@ This document defines the core domain model and key abstractions used throughout
 ### Agent
 An AI-powered program that can perform tasks by reasoning, using tools, and producing artifacts. Agents are opaque to the system — the platform manages their lifecycle but does not control their internal reasoning. Examples: Claude Code, Codex, Pi.
 
-### Harness
-The adapter layer that wraps a specific agent implementation and exposes it through the platform's universal interface. Each supported agent type has a corresponding harness. The harness translates between the platform's session protocol and the agent's native CLI/API.
+### Harness (Industry Term)
+In industry usage, a *harness* refers to the complete runtime wrapping an LLM that makes it a functional coding agent — the tools, context management, feedback loops, and execution environment. **Claude Code, Codex, and Pi are all coding harnesses.** We do not use this term as a system concept in our platform, but reference it for alignment with industry terminology.
 
-Think of it as: **Agent is the engine, Harness is the mounting bracket.**
+### Adapter
+The translation layer (provided by the [Sandbox Agent SDK](https://sandboxagent.dev/)) that normalizes different coding harnesses behind a universal HTTP API. The SDK handles the per-agent differences; our platform consumes the SDK's unified interface via a bridge sidecar.
+
+Think of it as: **The coding harness is the car. The adapter (SDK) is the OBD port that lets any diagnostic tool talk to any car.**
 
 ### Sandbox
 An isolated, stateful execution environment in which an agent runs. A sandbox consists of:
@@ -54,7 +57,7 @@ Tasks B and C run in parallel after A completes. Task D waits for both B and C.
 A set of pre-provisioned sandboxes ready to accept tasks. Pools are defined by:
 - **Sandbox template** (base image, pre-installed tools, volume size)
 - **Scale bounds** (min/max replicas)
-- **Agent harness type**
+- **Agent type** (via `AgentConfig` reference)
 
 Pools amortize sandbox startup cost by keeping warm instances available.
 
@@ -74,7 +77,7 @@ Tenant (Namespace)
 │       └── Session (0..N)
 ├── Workflow
 │   └── Task (1..N)
-└── HarnessConfig
+└── AgentConfig
 ```
 
 ## Lifecycle States
@@ -117,5 +120,5 @@ Pending → Scheduled → Running → [Succeeded | Failed | Cancelled]
 - A **Workflow** contains one or more **Tasks** connected by dependency edges.
 - A **Task** runs in exactly one **Sandbox** (but a Sandbox may be reused across Tasks).
 - A **Sandbox** belongs to a **Pool** and runs one **Session** at a time.
-- A **Harness** is configured per-Pool (all sandboxes in a pool use the same harness).
+- An **AgentConfig** is configured per-Pool (all sandboxes in a pool use the same agent type).
 - A **Tenant** owns Pools, Workflows, and all resources within its namespace.

--- a/spec/03-architecture-overview.md
+++ b/spec/03-architecture-overview.md
@@ -25,7 +25,7 @@ The system follows a layered architecture built on Kubernetes primitives. Each l
 │  └──────┬───────┘ └──────┬───────┘ └──────────┬───────────────┘ │
 │         │                │                     │                 │
 │  ┌──────▼───────┐ ┌──────▼───────┐ ┌──────────▼───────────────┐ │
-│  │  Task        │ │   Session    │ │   Harness                │ │
+│  │  Task        │ │   Session    │ │   Agent                  │ │
 │  │  Controller  │ │  Controller  │ │   Registry               │ │
 │  └──────────────┘ └──────────────┘ └──────────────────────────┘ │
 └──────────────────────────┬──────────────────────────────────────┘
@@ -72,11 +72,11 @@ All operators are written in Go using [controller-runtime](https://github.com/ku
 | **Workflow Controller** | `Workflow` CRs | Decomposes workflows into `Task` CRs, manages DAG execution order |
 | **Task Controller** | `Task` CRs | Claims a sandbox from the pool, creates a `Session` CR |
 | **Sandbox Controller** | `Sandbox` CRs | Manages pod lifecycle, volume provisioning, network policy |
-| **Session Controller** | `Session` CRs | Invokes the harness, streams events, captures results |
+| **Session Controller** | `Session` CRs | Invokes the bridge sidecar, streams events, captures results |
 | **Pool Controller** | `Pool` CRs | Autoscales sandboxes based on demand and pool configuration |
 
-### Harness Registry
-A configuration store (`HarnessConfig` CRs) mapping agent types to their container images and configuration. Each entry specifies the Sandbox Agent SDK version and bridge sidecar image for that agent type. See [spec 06](06-agent-harness-interface.md) for details.
+### Agent Registry
+A configuration store (`AgentConfig` CRs) mapping agent types to their container images and configuration. Each entry specifies the Sandbox Agent SDK version and bridge sidecar image for that agent type. See [spec 06](06-agent-adapter.md) for details.
 
 ### Data Plane
 The data plane consists of sandbox pods running actual agent workloads. Each sandbox pod contains:

--- a/spec/04-control-plane.md
+++ b/spec/04-control-plane.md
@@ -21,8 +21,8 @@ metadata:
   name: claude-code-pool
   namespace: team-alpha
 spec:
-  # Which agent harness to use
-  harnessRef:
+  # Which agent type to use
+  agentConfigRef:
     name: claude-code
 
   # Scaling configuration
@@ -89,7 +89,7 @@ metadata:
 spec:
   poolRef:
     name: claude-code-pool
-  harnessRef:
+  agentConfigRef:
     name: claude-code
 
   # Override pool defaults if needed
@@ -112,31 +112,30 @@ status:
       status: "True"
 ```
 
-### HarnessConfig
+### AgentConfig
 
-Defines how to run a specific agent type.
+Defines how to run a specific agent type. Configures the Sandbox Agent SDK and bridge sidecar for this agent.
 
 ```yaml
 apiVersion: factory.example.com/v1alpha1
-kind: HarnessConfig
+kind: AgentConfig
 metadata:
   name: claude-code
   namespace: team-alpha
 spec:
   # Agent identification
-  agentType: claude-code
+  agentType: claude-code        # Must match SDK's agent identifier
   displayName: "Claude Code"
 
-  # Container configuration
-  container:
-    image: ghcr.io/example/harness-claude-code:v0.1.0
-    command: ["/harness", "serve"]
-    ports:
-      - name: harness
-        containerPort: 8080
-    env:
-      - name: AGENT_BINARY
-        value: "/usr/local/bin/claude"
+  # Sandbox Agent SDK configuration
+  sdk:
+    image: ghcr.io/rivet-dev/sandbox-agent:v0.4.2
+    port: 2468
+
+  # Bridge sidecar configuration
+  bridge:
+    image: ghcr.io/example/factory-bridge:v0.1.0
+    port: 8080
     healthCheck:
       httpGet:
         path: /healthz
@@ -144,12 +143,14 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 10
 
-  # Session protocol
-  protocol:
-    type: http-sse          # http-sse | grpc-stream | stdio
-    sessionEndpoint: /sessions
-    eventEndpoint: /sessions/{id}/events
-    messageEndpoint: /sessions/{id}/messages
+  # Agent-specific settings
+  agentSettings:
+    contextFile: CLAUDE.md      # Which context file the agent reads
+    allowedTools:               # Tool restrictions (optional)
+      - bash
+      - read
+      - write
+      - edit
 
   # Credential requirements
   credentials:
@@ -157,7 +158,8 @@ spec:
       secretRef:
         name: anthropic-credentials
         key: api-key
-      required: true
+      host: api.anthropic.com
+      header: x-api-key
 ```
 
 ### Workflow
@@ -309,7 +311,7 @@ status:
 
 ### Sandbox Controller
 
-1. **On Sandbox create**: Create a Pod with the harness container, mount the PV, apply network policies, inject credentials from the HarnessConfig.
+1. **On Sandbox create**: Create a Pod with the SDK and bridge containers, mount the PV, apply network policies, inject credentials from the AgentConfig.
 
 2. **On Pod ready**: Set sandbox phase to `Ready`.
 
@@ -327,7 +329,7 @@ status:
 
 ### Session Controller
 
-1. **On Session create**: Connect to the harness HTTP/gRPC endpoint in the sandbox pod. Send the prompt. Begin streaming events to NATS.
+1. **On Session create**: Connect to the bridge sidecar endpoint in the sandbox pod. Send the prompt. Begin streaming events to NATS.
 
 2. **On event received**: Publish to NATS stream `sessions.<session-id>`. Update Session CR status with latest event summary.
 

--- a/spec/05-sandbox-runtime.md
+++ b/spec/05-sandbox-runtime.md
@@ -116,7 +116,7 @@ The warmup process runs in the init container and prepares the sandbox for work:
 2. **Git clone**: Clone specified repositories into `/workspace/repo/`.
 3. **Dependency install**: Run warmup commands (e.g., `npm install`, `pip install -r requirements.txt`).
 4. **Cache population**: Populate `.cache/` directories.
-5. **Health check**: Verify the harness is responsive.
+5. **Health check**: Verify the SDK and bridge sidecar are responsive.
 
 ### Warmup Optimization Strategies
 

--- a/spec/06-agent-adapter.md
+++ b/spec/06-agent-adapter.md
@@ -1,10 +1,10 @@
-# 06 — Agent Harness Interface
+# 06 — Agent Adapter Layer
 
 **Status:** DRAFT
 
 ## Overview
 
-The harness layer provides the interface between the orchestration control plane and the agent running inside a sandbox. Rather than building our own agent adapter framework, we adopt the [Sandbox Agent SDK](https://sandboxagent.dev/) as the in-sandbox runtime and build a thin Go bridge that connects it to our Kubernetes control plane.
+The adapter layer provides the interface between the orchestration control plane and the coding harness (agent) running inside a sandbox. Rather than building our own agent adapter framework, we adopt the [Sandbox Agent SDK](https://sandboxagent.dev/) as the in-sandbox runtime and build a thin Go bridge that connects it to our Kubernetes control plane.
 
 ### Why Sandbox Agent SDK
 
@@ -283,13 +283,13 @@ After a session completes:
 1. **Extract output artifacts**: Read specified paths via `/v1/fs/file`, upload to object storage.
 2. **Collect metadata**: Token usage, duration, tool call counts from the event stream.
 
-## HarnessConfig CR
+## AgentConfig CR
 
-The `HarnessConfig` CR is simplified — it no longer defines how to build an adapter, just how to configure the SDK for a specific agent:
+The `AgentConfig` CR is simplified — it no longer defines how to build an adapter, just how to configure the SDK for a specific agent:
 
 ```yaml
 apiVersion: factory.example.com/v1alpha1
-kind: HarnessConfig
+kind: AgentConfig
 metadata:
   name: claude-code
   namespace: team-alpha
@@ -308,7 +308,7 @@ spec:
     port: 8080
 
   # Agent-specific configuration
-  agentConfig:
+  agentSettings:
     contextFile: CLAUDE.md      # Which context file the agent reads
     allowedTools:               # Tool restrictions (optional)
       - bash
@@ -330,7 +330,7 @@ spec:
 
 Because we use the Sandbox Agent SDK, adding a new agent is straightforward:
 
-1. **If the SDK already supports the agent** (Claude Code, Codex, Pi, OpenCode, Amp, Cursor): Create a `HarnessConfig` CR with the agent type. No code changes needed.
+1. **If the SDK already supports the agent** (Claude Code, Codex, Pi, OpenCode, Amp, Cursor): Create a `AgentConfig` CR with the agent type. No code changes needed.
 
 2. **If the SDK doesn't support the agent yet**: Either contribute an adapter upstream to the SDK (Rust), or request it from the SDK maintainers. The SDK's adapter model is designed for this.
 
@@ -345,7 +345,7 @@ The control plane never changes — it only talks to the bridge sidecar.
 | Risk | Mitigation |
 |------|-----------|
 | SDK development stalls | Apache 2.0 — we can fork. Single Rust binary is self-contained. |
-| SDK API changes break us | Pin SDK version per HarnessConfig. Generated Go client catches breaking changes at build time. |
+| SDK API changes break us | Pin SDK version per `AgentConfig` CR. Generated Go client catches breaking changes at build time. |
 | Rust binary is opaque | We don't need to modify it — only consume its HTTP API. We can contribute upstream for features we need. |
 | Performance overhead of extra process | Rust binary is ~5MB, starts in <1s, uses minimal memory. Negligible compared to the agent process. |
 

--- a/spec/07-orchestration-engine.md
+++ b/spec/07-orchestration-engine.md
@@ -159,7 +159,7 @@ Timeouts apply at two levels:
 - **Task timeout**: Maximum time for a single task (including retries). Default: 1h.
 - **Workflow timeout**: Maximum time for the entire workflow. Default: 24h.
 
-When a timeout fires, the session is cancelled gracefully (the harness sends a cancel signal to the agent), then forcefully killed after a grace period.
+When a timeout fires, the session is cancelled gracefully (the bridge sidecar sends a cancel signal to the agent via the SDK), then forcefully killed after a grace period.
 
 ## Advanced Patterns
 

--- a/spec/08-observability-and-events.md
+++ b/spec/08-observability-and-events.md
@@ -14,7 +14,7 @@ Every agent session, task, and workflow produces structured telemetry. Observabi
 Agent Process
     │
     ▼ (native events)
-Harness (Event Normalizer)
+Sandbox Agent SDK → Bridge Sidecar (Event Normalizer)
     │
     ▼ (normalized events)
 NATS JetStream
@@ -115,7 +115,7 @@ Trace context is propagated:
 
 The OpenTelemetry Collector receives spans from:
 - Control plane operators (Go instrumentation via `go.opentelemetry.io/otel`)
-- Harness processes (span per tool call)
+- Bridge sidecar processes (span per tool call)
 - NATS event metadata (correlated by trace ID)
 
 Exporters: Jaeger, Tempo, or any OTLP-compatible backend.

--- a/spec/09-security-model.md
+++ b/spec/09-security-model.md
@@ -95,7 +95,7 @@ Each sandbox gets a NetworkPolicy restricting network access:
 1. **Deny all by default**: No ingress or egress without explicit rules.
 2. **Allow DNS**: Required for name resolution.
 3. **Allow specific egress**: Only allowlisted destinations (LLM APIs, git hosts, package registries).
-4. **Allow control plane ingress**: The harness HTTP port is accessible only from the Session Controller.
+4. **Allow control plane ingress**: The bridge sidecar HTTP port is accessible only from the Session Controller.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -157,7 +157,7 @@ This is inspired by Cloudflare Dynamic Workers' `globalOutbound` pattern.
 | Role | Scope | Permissions |
 |------|-------|-------------|
 | `factory-admin` | Cluster | Full access to all resources |
-| `tenant-admin` | Namespace | Manage pools, harness configs, view all workflows |
+| `tenant-admin` | Namespace | Manage pools, agent configs, view all workflows |
 | `developer` | Namespace | Submit workflows, view own tasks and sessions |
 | `viewer` | Namespace | Read-only access to workflows and sessions |
 
@@ -210,7 +210,7 @@ Task Secrets (injected per-task)
 
 ### Secret Injection Flow
 
-1. `HarnessConfig` declares required credentials.
+1. `AgentConfig` declares required credentials.
 2. `Pool` spec references secrets by `secretRef`.
 3. Sandbox Controller mounts secrets as projected volumes.
 4. Credential proxy reads secrets from the volume.

--- a/spec/10-prior-art.md
+++ b/spec/10-prior-art.md
@@ -16,7 +16,7 @@ A Rust-based universal control layer for coding agents. It wraps six agents (Cla
 
 ### Decision: Adopt as In-Sandbox Runtime
 
-After deeper analysis of the SDK's OpenAPI spec, we decided to **adopt the Sandbox Agent SDK as the in-sandbox agent runtime** rather than building our own adapter layer. See [spec 06](06-agent-harness-interface.md) for the full rationale and integration design.
+After deeper analysis of the SDK's OpenAPI spec, we decided to **adopt the Sandbox Agent SDK as the in-sandbox agent runtime** rather than building our own adapter layer. See [spec 06](06-agent-adapter.md) for the full rationale and integration design.
 
 ### API Surface (from OpenAPI spec)
 
@@ -55,7 +55,7 @@ This is far more capable than what we'd build ourselves. Key features we get for
 | Risk | Mitigation |
 |------|-----------|
 | SDK development stalls | Apache 2.0 license — we can fork. Self-contained Rust binary. |
-| API breaking changes | Pin version per HarnessConfig CR. Generated Go client catches breaks at build time. |
+| API breaking changes | Pin version per `AgentConfig` CR. Generated Go client catches breaks at build time. |
 | Missing agent support | Contribute upstream, or use `/v1/processes` as a fallback for raw process management. |
 | Rust binary is opaque | We only consume its HTTP API — no need to modify internals. |
 
@@ -76,7 +76,7 @@ A Cloudflare runtime feature that spins up V8 isolates at runtime to execute LLM
 | **Capability-based security via bindings** | Dynamic Workers have zero capabilities by default; the parent explicitly grants access. Our credential proxy and network policies follow the same principle — deny-all default, explicit allowlisting. |
 | **`globalOutbound` for credential safety** | The parent intercepts outbound HTTP requests and injects credentials. This directly inspired our credential proxy sidecar design (spec 09). |
 | **Code Mode** | The idea of having an LLM generate a program rather than making sequential tool calls is powerful. While not directly applicable to our orchestration model, it's relevant for custom tool-using agents (UC2). |
-| **Virtual filesystem** | Their `@cloudflare/shell` package provides a transactional virtual filesystem. Our PV-backed workspace is the Kubernetes equivalent, but we should consider supporting similar file operation APIs in the harness. |
+| **Virtual filesystem** | Their `@cloudflare/shell` package provides a transactional virtual filesystem. Our PV-backed workspace is the Kubernetes equivalent, and the Sandbox Agent SDK provides similar file operation APIs via `/v1/fs`. |
 
 ### Where We Diverge
 
@@ -107,12 +107,12 @@ A TypeScript monorepo providing a minimal coding agent (`pi-coding-agent`), a mu
 
 | Concept | How It Applies |
 |---------|---------------|
-| **RPC over stdin/stdout** | Pi's JSONL-framed RPC mode is ideal for harness integration. This is the cleanest agent control interface we've seen and directly maps to our Harness interface. |
+| **RPC over stdin/stdout** | Pi's JSONL-framed RPC mode is ideal for adapter integration. The Sandbox Agent SDK uses this to communicate with Pi. |
 | **Steering messages** | Messages queued and delivered after tool execution completes. This enables mid-task redirection without interrupting the agent's current operation. We adopted this in our Session interface (spec 06). |
 | **Session tree with branching** | Sessions stored with `id`/`parentId` enabling branching. Useful for exploring alternative approaches to a task. We should consider this for advanced workflow patterns. |
-| **Extension system** | Pi's minimal core + extension model (skills, extensions, themes) demonstrates how to keep the agent harness thin while enabling customization. Our HarnessConfig should support extension loading. |
-| **Context file hierarchy** | `AGENTS.md`/`CLAUDE.md` loaded from home and parent directories. Our harness should write task context to these standard files rather than inventing a new mechanism. |
-| **Automatic compaction** | Proactive context compaction on overflow. Long-running agent sessions in our system will hit context limits — the harness should support compaction strategies. |
+| **Extension system** | Pi's minimal core + extension model (skills, extensions, themes) demonstrates how to keep the coding harness thin while enabling customization. Our `AgentConfig` should support extension loading. |
+| **Context file hierarchy** | `AGENTS.md`/`CLAUDE.md` loaded from home and parent directories. Our bridge sidecar writes task context to these standard files rather than inventing a new mechanism. |
+| **Automatic compaction** | Proactive context compaction on overflow. Long-running agent sessions in our system will hit context limits — the coding harness handles this internally. |
 
 ### Where We Diverge
 
@@ -126,7 +126,7 @@ A TypeScript monorepo providing a minimal coding agent (`pi-coding-agent`), a mu
 
 ### Potential Integration
 
-Pi's RPC mode makes it an excellent first-class citizen in our system. The Pi harness adapter can communicate via stdin/stdout JSONL, getting native steering support and clean event normalization. Pi's `pi-ai` library could also be useful if we ever need to build meta-agents that orchestrate at the LLM level (e.g., task decomposition agents).
+Pi's RPC mode makes it an excellent first-class citizen in our system. The Sandbox Agent SDK communicates with Pi via stdin/stdout JSONL, getting native steering support and clean event normalization. Pi's `pi-ai` library could also be useful if we ever need to build meta-agents that orchestrate at the LLM level (e.g., task decomposition agents).
 
 ---
 
@@ -166,7 +166,7 @@ The Workflow Controller is the most complex operator in our system. Argo Workflo
 - Handles fan-out/fan-in, loops, recursion
 
 **Arguments for building our own:**
-- Argo Workflows is generic — our workflows are agent-specific (sessions, harnesses, pools)
+- Argo Workflows is generic — our workflows are agent-specific (sessions, sandboxes, pools)
 - Argo's step containers are short-lived; our sandboxes are long-lived and reusable
 - Tight integration with sandbox pools and session management is easier in a custom controller
 - Argo introduces significant operational overhead (its own set of CRDs, controllers, database)

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This specification describes an **agent orchestration system built on Kubernetes** that enables running, managing, and coordinating fleets of AI coding agents in stateful sandboxes. The system provides a universal interface across multiple agent harnesses (Claude Code, Codex, Pi, etc.) and supports use cases ranging from fleet-based software development to custom tool-using agents.
+This specification describes an **agent orchestration system built on Kubernetes** that enables running, managing, and coordinating fleets of AI coding agents (harnesses) in stateful sandboxes. The system provides a universal adapter interface across multiple coding harnesses (Claude Code, Codex, Pi, etc.) and supports use cases ranging from fleet-based software development to custom tool-using agents.
 
 ## Reading Guide
 
@@ -27,7 +27,7 @@ The spec is organized for **progressive disclosure**. Start with the vision, the
 |----------|-------------|
 | [04 - Control Plane](04-control-plane.md) | Kubernetes operators, Custom Resource Definitions, and API design |
 | [05 - Sandbox Runtime](05-sandbox-runtime.md) | Sandbox lifecycle, stateful environments, filesystem and dependency caching |
-| [06 - Agent Harness Interface](06-agent-harness-interface.md) | Universal adapter layer for coding agents, session management, event streaming |
+| [06 - Agent Adapter Layer](06-agent-adapter.md) | Sandbox Agent SDK integration, bridge sidecar, session management, event streaming |
 | [07 - Orchestration Engine](07-orchestration-engine.md) | Task decomposition, DAG execution, multi-agent workflows |
 
 ### Layer 4: Cross-Cutting Concerns
@@ -48,7 +48,7 @@ The spec is organized for **progressive disclosure**. Start with the vision, the
 - **Primary language:** Go
 - **Runtime platform:** Kubernetes
 - **CNCF ecosystem:** Leverage existing projects where they fit (detailed in individual specs)
-- **Secondary languages:** Rust or TypeScript where ecosystem demands it (e.g., agent harness adapters)
+- **Secondary languages:** Rust or TypeScript where ecosystem demands it (e.g., the Sandbox Agent SDK is Rust)
 
 ## Status
 


### PR DESCRIPTION
## Summary

- **Rename `HarnessConfig` CR → `AgentConfig` CR** across all spec documents
- **Rename `06-agent-harness-interface.md` → `06-agent-adapter.md`**
- **Redefine terminology in spec 02** to align with industry usage: "harness" now correctly refers to the complete agent runtime (Claude Code, Codex, Pi), while "adapter" refers to the translation layer (Sandbox Agent SDK)

## Rationale

In industry usage (Anthropic, OpenAI, Pi, LangChain, Martin Fowler), "harness" means the complete runtime wrapping an LLM — Claude Code, Codex, and Pi *are* coding harnesses. Our spec was using "harness" to mean "adapter", which creates confusion for anyone familiar with the established terminology.

Key terminology changes:
- `HarnessConfig` → `AgentConfig` (CRD kind)
- `harnessRef` → `agentConfigRef` (field references)
- `Harness Registry` → `Agent Registry` (architecture component)
- All "the harness does X" → "the bridge sidecar does X" or "the SDK does X"

## Test plan

- [ ] Verify no remaining `HarnessConfig` or `harnessRef` references across all specs
- [ ] Verify all cross-document links (especially to `06-agent-adapter.md`) resolve correctly
- [ ] Review spec 02 terminology definitions for clarity

https://claude.ai/code/session_01JByrczUnBqBCnqwZ5RKizj