### PR TITLE
Broaden scope from coding agents to general-purpose agents

### DIFF
--- a/spec/01-vision-and-goals.md
+++ b/spec/01-vision-and-goals.md
@@ -6,12 +6,12 @@
 
 Build a Kubernetes-native platform that orchestrates fleets of AI agents in stateful, isolated sandboxes. The platform treats agents as a first-class workload type — similar to how Kubernetes treats containers — providing primitives for lifecycle management, scheduling, observability, and coordination.
 
-The system is **agent-agnostic**: it does not embed any specific coding agent. Instead, it provides a universal adapter interface (via the [Sandbox Agent SDK](https://sandboxagent.dev/)) that supports any coding harness (Claude Code, Codex, Pi, Aider, etc.), allowing operators to choose — or mix — agents based on the task at hand.
+The system is **agent-agnostic**: it does not embed any specific agent. Instead, it provides a universal adapter interface (via the [Sandbox Agent SDK](https://sandboxagent.dev/)) that supports any agent harness (Claude Code, Codex, Pi, Aider, etc.), allowing operators to choose — or mix — agents based on the task at hand.
 
 ## Goals
 
 ### G1: Universal Agent Runtime
-Support multiple coding harnesses through a common adapter interface. Operators should be able to swap agents without changing their orchestration logic. Initially target: Claude Code, Codex, and Pi.
+Support multiple agent harnesses through a common adapter interface. Operators should be able to swap agents without changing their orchestration logic. Initially target: Claude Code, Codex, and Pi.
 
 ### G2: Stateful Sandboxes
 Provide persistent, isolated execution environments where agents can work across sessions without re-cloning repositories or reinstalling dependencies. Sandbox state (filesystem, installed packages, running processes) survives agent restarts and can be snapshotted/restored.
@@ -30,21 +30,21 @@ Isolate tenants at the namespace level. Agents run in sandboxed containers with 
 
 ## Use Cases
 
-### UC1: Fleet Software Development
-An engineering team submits a feature specification. The system decomposes it into implementation tasks, assigns each to a coding agent, and coordinates integration. Human reviewers approve merge-ready results.
+### UC1: Fleet Task Execution
+An organization submits a complex goal (feature specification, research brief, data migration plan). The system decomposes it into tasks, assigns each to an agent, and coordinates results. Human reviewers approve final outputs. Example: an engineering team decomposes a feature spec into implementation subtasks across a pool of coding agents.
 
 ### UC2: Custom Tool-Using Agents
 A platform team builds domain-specific agents that use MCP tools to interact with internal systems (databases, APIs, dashboards). The orchestration system manages their lifecycle and provides sandboxed execution.
 
-### UC3: CI/CD Agent Integration
-Coding agents are triggered by CI events (PR opened, review requested, test failure) and run within the orchestration system to suggest fixes, write tests, or perform code review.
+### UC3: Event-Triggered Agents
+Agents are triggered by external events (webhooks, schedules, CI signals) and run within the orchestration system to perform tasks autonomously. Examples: a coding agent responds to CI failures with fixes, a personal assistant agent processes incoming emails, or a monitoring agent triages alerts.
 
 ### UC4: Batch Processing
 A large-scale migration or refactoring task is split across hundreds of repositories. The system schedules agents across the fleet, throttling concurrency to respect API rate limits and cluster resources.
 
 ## Non-Goals
 
-- **Building a coding agent.** We orchestrate existing agents; we don't build one.
+- **Building an agent.** We orchestrate existing agents; we don't build one.
 - **Replacing Kubernetes.** We extend Kubernetes, not replace it.
 - **LLM hosting.** We call LLM APIs; we don't serve models. (GPU scheduling for self-hosted models is a future consideration but out of scope for v1.)
 - **General-purpose workflow engine.** The orchestration engine is purpose-built for agent workloads. Use Argo Workflows or Tekton for generic CI/CD pipelines.

--- a/spec/02-concepts-and-terminology.md
+++ b/spec/02-concepts-and-terminology.md
@@ -10,12 +10,12 @@ This document defines the core domain model and key abstractions used throughout
 An AI-powered program that can perform tasks by reasoning, using tools, and producing artifacts. Agents are opaque to the system — the platform manages their lifecycle but does not control their internal reasoning. Examples: Claude Code, Codex, Pi.
 
 ### Harness (Industry Term)
-In industry usage, a *harness* refers to the complete runtime wrapping an LLM that makes it a functional coding agent — the tools, context management, feedback loops, and execution environment. **Claude Code, Codex, and Pi are all coding harnesses.** We do not use this term as a system concept in our platform, but reference it for alignment with industry terminology.
+In industry usage, a *harness* refers to the complete runtime wrapping an LLM that makes it a functional agent — the tools, context management, feedback loops, and execution environment. **Claude Code, Codex, and Pi are all agent harnesses.** We do not use this term as a system concept in our platform, but reference it for alignment with industry terminology.
 
 ### Adapter
-The translation layer (provided by the [Sandbox Agent SDK](https://sandboxagent.dev/)) that normalizes different coding harnesses behind a universal HTTP API. The SDK handles the per-agent differences; our platform consumes the SDK's unified interface via a bridge sidecar.
+The translation layer (provided by the [Sandbox Agent SDK](https://sandboxagent.dev/)) that normalizes different agent harnesses behind a universal HTTP API. The SDK handles the per-agent differences; our platform consumes the SDK's unified interface via a bridge sidecar.
 
-Think of it as: **The coding harness is the car. The adapter (SDK) is the OBD port that lets any diagnostic tool talk to any car.**
+Think of it as: **The agent harness is the car. The adapter (SDK) is the OBD port that lets any diagnostic tool talk to any car.**
 
 ### Sandbox
 An isolated, stateful execution environment in which an agent runs. A sandbox consists of:
@@ -39,7 +39,7 @@ Sessions are immutable once completed and can be replayed for debugging.
 A unit of work assigned to an agent. Tasks are defined by:
 - A **specification** (natural language instruction, context files, constraints)
 - **Inputs** (artifacts from upstream tasks, configuration)
-- **Expected outputs** (files modified, PRs created, test results)
+- **Expected outputs** (files modified, reports generated, API calls made)
 - **Resource requirements** (sandbox size, timeout, agent type preference)
 
 ### Workflow

--- a/spec/06-agent-adapter.md
+++ b/spec/06-agent-adapter.md
@@ -4,11 +4,11 @@
 
 ## Overview
 
-The adapter layer provides the interface between the orchestration control plane and the coding harness (agent) running inside a sandbox. Rather than building our own agent adapter framework, we adopt the [Sandbox Agent SDK](https://sandboxagent.dev/) as the in-sandbox runtime and build a thin Go bridge that connects it to our Kubernetes control plane.
+The adapter layer provides the interface between the orchestration control plane and the agent harness running inside a sandbox. Rather than building our own agent adapter framework, we adopt the [Sandbox Agent SDK](https://sandboxagent.dev/) as the in-sandbox runtime and build a thin Go bridge that connects it to our Kubernetes control plane.
 
 ### Why Sandbox Agent SDK
 
-The Sandbox Agent SDK already solves the hardest part of this problem: normalizing across diverse coding agents. Building our own would mean:
+The Sandbox Agent SDK already solves the hardest part of this problem: normalizing across diverse agent harnesses. Building our own would mean:
 
 - Writing and maintaining individual adapters for Claude Code, Codex, Pi, OpenCode, Amp, Cursor (and future agents)
 - Designing a session protocol, event schema, and process management layer

--- a/spec/10-prior-art.md
+++ b/spec/10-prior-art.md
@@ -12,7 +12,7 @@ This document analyzes existing projects that solve related problems. Each is ev
 
 ### What It Does
 
-A Rust-based universal control layer for coding agents. It wraps six agents (Claude Code, Codex, OpenCode, Cursor, Amp, Pi) behind a single HTTP/SSE API with a normalized event schema. Runs inside sandbox environments from various providers (E2B, Daytona, Modal, Docker, etc.).
+A Rust-based universal control layer for AI agents. It wraps six agents (Claude Code, Codex, OpenCode, Cursor, Amp, Pi) behind a single HTTP/SSE API with a normalized event schema. Runs inside sandbox environments from various providers (E2B, Daytona, Modal, Docker, etc.).
 
 ### Decision: Adopt as In-Sandbox Runtime
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This specification describes an **agent orchestration system built on Kubernetes** that enables running, managing, and coordinating fleets of AI coding agents (harnesses) in stateful sandboxes. The system provides a universal adapter interface across multiple coding harnesses (Claude Code, Codex, Pi, etc.) and supports use cases ranging from fleet-based software development to custom tool-using agents.
+This specification describes an **agent orchestration system built on Kubernetes** that enables running, managing, and coordinating fleets of AI agents in stateful sandboxes. The system provides a universal adapter interface (via the Sandbox Agent SDK) across multiple agent harnesses (Claude Code, Codex, Pi, etc.) and supports use cases ranging from fleet-based software development to personal assistants, custom tool-using agents, and batch automation.
 
 ## Reading Guide
 


### PR DESCRIPTION
## Summary
- Replace "coding agent" and "coding harness" with "agent" and "agent harness" in all definitional language across spec
- Generalize UC1 from "Fleet Software Development" to "Fleet Task Execution" (coding is now one example)
- Generalize UC3 from "CI/CD Agent Integration" to "Event-Triggered Agents" (adds personal assistant, monitoring examples)
- Broaden task output examples from "PRs created, test results" to "reports generated, API calls made"

## Context
The platform should support any AI agent use case — coding agents, personal assistants, research agents, automation agents — not just software development. This change relaxes the spec language so coding is a primary use case but not the only one.

## What stays the same
- Concrete examples in workflow YAML (implement-auth-feature) remain code-focused — they're good examples
- Pi prior art section correctly describes Pi as a "coding agent" since that's what it is
- Use cases still mention coding as one example among others

## Test plan
- [ ] Verify no definitional language assumes coding-only scope
- [ ] Confirm remaining "coding" references are in example/prior-art context

https://claude.ai/code/session_01JByrczUnBqBCnqwZ5RKizj