### PR TITLE
Add usage examples for coding agent and personal assistant

### DIFF
--- a/examples/coding-agent-with-k8s-access/README.md
+++ b/examples/coding-agent-with-k8s-access/README.md
@@ -1,0 +1,79 @@
+# Coding Agent with Kubernetes Access
+
+This example sets up a Claude Code agent that can build, deploy, and troubleshoot an application in a dedicated Kubernetes namespace. The agent has access to `kubectl` inside its sandbox and a scoped ServiceAccount that grants it permissions to a target namespace.
+
+## Use Case
+
+A development team wants an AI agent that can:
+
+1. Write application code
+2. Build container images
+3. Deploy to a staging namespace (`app-staging`)
+4. Inspect pod logs, events, and resource status to troubleshoot issues
+5. Iterate on fixes until the deployment is healthy
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  team-alpha namespace                       │
+│                                             │
+│  ┌────────────┐    ┌─────────────────────┐  │
+│  │ Pool       │───►│ Sandbox Pod         │  │
+│  │ (claude-k8s│    │  ├ SDK              │  │
+│  │  -pool)    │    │  ├ Bridge           │  │
+│  └────────────┘    │  └ Agent (Claude)   │  │
+│                    │    └ kubectl access ─┼──┼──► app-staging namespace
+│  ┌────────────┐    │      (ServiceAccount)│  │
+│  │ AgentConfig│    └─────────────────────┘  │
+│  │ (claude-k8s│                             │
+│  └────────────┘                             │
+└─────────────────────────────────────────────┘
+```
+
+The agent's sandbox mounts a ServiceAccount token that grants RBAC permissions to the `app-staging` namespace. Network policies allow the agent to reach the Kubernetes API server and container registry.
+
+## Manifests
+
+### 1. Target namespace and RBAC
+
+The agent needs permissions in the namespace it deploys to. We create a Role with deployment-related permissions and bind it to a ServiceAccount that the sandbox pod uses.
+
+See [`manifests/rbac.yaml`](manifests/rbac.yaml).
+
+### 2. AgentConfig
+
+Configures Claude Code with `kubectl` pre-installed in the warmup and credentials for both the Anthropic API and the container registry.
+
+See [`manifests/agentconfig.yaml`](manifests/agentconfig.yaml).
+
+### 3. Pool
+
+A pool with `kubectl` and Docker CLI in the warmup image, network access to the K8s API server and container registry, and the sandbox ServiceAccount mounted.
+
+See [`manifests/pool.yaml`](manifests/pool.yaml).
+
+### 4. Task
+
+A standalone task that asks the agent to build, deploy, and verify an application.
+
+See [`manifests/task.yaml`](manifests/task.yaml).
+
+## How It Works
+
+1. The **Pool Controller** pre-provisions sandboxes from the pool template. Each sandbox pod runs with the `sandbox-deployer` ServiceAccount, which has RBAC permissions in `app-staging`.
+
+2. The **Task Controller** claims a sandbox and creates a Session. The bridge sidecar writes the task prompt and context files into the sandbox.
+
+3. **Claude Code** starts working: it writes code, builds an image, runs `kubectl apply`, and checks `kubectl get pods` to verify the deployment.
+
+4. If pods crash, the agent reads logs with `kubectl logs` and iterates on fixes — all within the same stateful sandbox so it doesn't lose context.
+
+5. On completion, the bridge extracts output artifacts (the final manifests) and publishes a session-complete event.
+
+## Key Points
+
+- **ServiceAccount scoping**: The sandbox pod's ServiceAccount only has access to `app-staging`, not the broader cluster. The agent cannot modify the orchestration namespace or other tenants.
+- **Network policy**: Egress is restricted to the K8s API server, container registry, and Anthropic API. The agent cannot reach arbitrary endpoints.
+- **Credential proxy**: The Anthropic API key is injected by the bridge sidecar's credential proxy — the agent never sees raw credentials.
+- **Statefulness**: The sandbox retains the cloned repo, built artifacts, and installed tools across retries. If the agent fails and retries, it picks up where it left off.

--- a/examples/coding-agent-with-k8s-access/manifests/agentconfig.yaml
+++ b/examples/coding-agent-with-k8s-access/manifests/agentconfig.yaml
@@ -1,0 +1,40 @@
+apiVersion: factory.example.com/v1alpha1
+kind: AgentConfig
+metadata:
+  name: claude-k8s
+  namespace: team-alpha
+spec:
+  agentType: claude-code
+  displayName: "Claude Code (K8s Deploy)"
+
+  sdk:
+    image: ghcr.io/rivet-dev/sandbox-agent:v0.4.2
+    port: 2468
+
+  bridge:
+    image: ghcr.io/example/factory-bridge:v0.1.0
+    port: 8080
+    healthCheck:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+
+  agentSettings:
+    contextFile: CLAUDE.md
+    allowedTools:
+      - bash
+      - read
+      - write
+      - edit
+      - glob
+      - grep
+
+  credentials:
+    - name: ANTHROPIC_API_KEY
+      secretRef:
+        name: anthropic-credentials
+        key: api-key
+      host: api.anthropic.com
+      header: x-api-key

--- a/examples/coding-agent-with-k8s-access/manifests/pool.yaml
+++ b/examples/coding-agent-with-k8s-access/manifests/pool.yaml
@@ -1,0 +1,60 @@
+apiVersion: factory.example.com/v1alpha1
+kind: Pool
+metadata:
+  name: claude-k8s-pool
+  namespace: team-alpha
+spec:
+  agentConfigRef:
+    name: claude-k8s
+
+  replicas:
+    min: 1
+    max: 5
+    idleTimeout: 15m
+    scaleUpThreshold: 0.8
+
+  sandboxTemplate:
+    # ServiceAccount with RBAC access to app-staging
+    serviceAccountName: sandbox-deployer
+
+    resources:
+      requests:
+        cpu: "2"
+        memory: "4Gi"
+      limits:
+        cpu: "4"
+        memory: "8Gi"
+
+    storage:
+      size: 50Gi
+      storageClassName: fast-ssd
+      reclaimPolicy: Retain
+
+    warmup:
+      image: ghcr.io/example/sandbox-base:latest
+      commands:
+        # Install kubectl
+        - |
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        # Install Docker CLI (for building images)
+        - |
+          apt-get update && apt-get install -y docker-ce-cli
+        # Install common build tools
+        - |
+          apt-get install -y build-essential git
+
+    networkPolicy:
+      egressRules:
+        # Anthropic API (for agent LLM calls)
+        - to: ["api.anthropic.com"]
+          ports: [443]
+        # Kubernetes API server (for kubectl)
+        - to: ["kubernetes.default.svc"]
+          ports: [443]
+        # Container registry (for pushing/pulling images)
+        - to: ["ghcr.io", "*.githubusercontent.com"]
+          ports: [443]
+        # Git (for cloning repos)
+        - to: ["github.com"]
+          ports: [443]

--- a/examples/coding-agent-with-k8s-access/manifests/rbac.yaml
+++ b/examples/coding-agent-with-k8s-access/manifests/rbac.yaml
@@ -1,0 +1,51 @@
+# Target namespace where the agent deploys applications
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-staging
+---
+# ServiceAccount for sandbox pods — lives in the orchestration namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox-deployer
+  namespace: team-alpha
+---
+# Role granting deployment permissions in app-staging
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox-deployer
+  namespace: app-staging
+rules:
+  # Workload management
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Core resources
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "secrets", "serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Pod troubleshooting
+  - apiGroups: [""]
+    resources: ["pods/log", "pods/status", "events"]
+    verbs: ["get", "list", "watch"]
+  # Networking
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+# Bind the role to the sandbox ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-deployer
+  namespace: app-staging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sandbox-deployer
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-deployer
+    namespace: team-alpha

--- a/examples/coding-agent-with-k8s-access/manifests/task.yaml
+++ b/examples/coding-agent-with-k8s-access/manifests/task.yaml
@@ -1,0 +1,27 @@
+apiVersion: factory.example.com/v1alpha1
+kind: Task
+metadata:
+  name: deploy-web-app
+  namespace: team-alpha
+spec:
+  poolRef:
+    name: claude-k8s-pool
+
+  prompt: |
+    You have access to the app-staging Kubernetes namespace via kubectl.
+
+    1. Clone the repository at https://github.com/example/web-app.git
+    2. Review the application code and write a Dockerfile
+    3. Build the container image and push to ghcr.io/example/web-app:latest
+    4. Write Kubernetes manifests (Deployment, Service) and apply them to app-staging
+    5. Wait for the deployment to be ready. If pods are failing, inspect logs and fix the issue.
+    6. Verify the service is reachable by port-forwarding and making a test request.
+
+    Save all manifests to /workspace/output/k8s/ when done.
+
+  outputs:
+    - path: /workspace/output/k8s/
+      artifact: k8s-manifests
+
+  timeout: 30m
+  retries: 2

--- a/examples/personal-assistant/README.md
+++ b/examples/personal-assistant/README.md
@@ -1,0 +1,82 @@
+# Personal Assistant with MCP Tools
+
+This example sets up a Pi-based personal assistant agent with access to MCP servers for calendar management and email. ToolHive manages the MCP servers, and a VirtualMCPServer aggregates them behind a single endpoint.
+
+## Use Case
+
+A user wants a personal assistant agent that can:
+
+1. Read and manage their Google Calendar (check availability, create events)
+2. Read and draft emails via Gmail
+3. Answer questions that require cross-referencing both (e.g., "Schedule a follow-up meeting with everyone from yesterday's email thread")
+
+The agent does not write code — it uses MCP tools to interact with external services.
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  assistant-ns namespace                                       │
+│                                                               │
+│  ┌────────────┐    ┌─────────────────────┐                    │
+│  │ Pool       │───►│ Sandbox Pod         │                    │
+│  │ (assistant │    │  ├ SDK              │                    │
+│  │  -pool)    │    │  ├ Bridge ──────────┼──► vMCP endpoint   │
+│  └────────────┘    │  └ Agent (Pi)       │         │          │
+│                    └─────────────────────┘         │          │
+│  ┌────────────┐                                    │          │
+│  │ AgentConfig│         ┌──────────────────────────┘          │
+│  │ (pi-asst)  │         ▼                                     │
+│  └────────────┘    ┌─────────────────────────────────┐        │
+│                    │ VirtualMCPServer (ToolHive)      │        │
+│                    │  ├ google-calendar MCP server    │        │
+│                    │  └ gmail MCP server              │        │
+│                    └─────────────────────────────────┘        │
+└───────────────────────────────────────────────────────────────┘
+```
+
+The agent connects to a single vMCP endpoint. ToolHive handles routing to the correct backend MCP server, tool namespacing (to avoid conflicts), and credential management for Google APIs.
+
+## Manifests
+
+### 1. ToolHive MCP servers
+
+Two ToolHive `MCPServer` resources — one for Google Calendar, one for Gmail — grouped by an `MCPGroup`, and exposed through a `VirtualMCPServer`.
+
+See [`manifests/toolhive.yaml`](manifests/toolhive.yaml).
+
+### 2. AgentConfig
+
+Configures Pi as the agent runtime. Pi is a lightweight agent framework well-suited for non-coding tasks. No special tools needed beyond MCP access.
+
+See [`manifests/agentconfig.yaml`](manifests/agentconfig.yaml).
+
+### 3. Pool
+
+A minimal pool — personal assistant workloads are lightweight. MCP tools are provided via the vMCP reference. Network access is limited to Google APIs and the Anthropic API.
+
+See [`manifests/pool.yaml`](manifests/pool.yaml).
+
+### 4. Task
+
+An example task showing how a user would interact with the assistant.
+
+See [`manifests/task.yaml`](manifests/task.yaml).
+
+## How It Works
+
+1. The **platform operator** deploys the ToolHive MCP servers for Google Calendar and Gmail. ToolHive runs each MCP server in its own container with secret injection for Google OAuth tokens. The `VirtualMCPServer` aggregates both behind a single HTTP endpoint with namespaced tool names (e.g., `calendar_list_events`, `gmail_search_messages`).
+
+2. The **Pool** references the vMCP via `mcpTools.vmcpRef`. When a sandbox is provisioned, the bridge sidecar configures the agent's MCP client to connect to the vMCP Service endpoint.
+
+3. When a **Task** is submitted, the agent (Pi) receives the prompt and can discover available MCP tools. It calls `calendar_list_events` to check tomorrow's schedule, `gmail_search_messages` to find relevant threads, and `calendar_create_event` to schedule meetings.
+
+4. The agent never handles OAuth tokens directly — ToolHive injects credentials at the MCP server layer. The bridge sidecar's credential proxy handles the Anthropic API key separately.
+
+## Key Points
+
+- **ToolHive manages MCP lifecycle**: MCP servers run as containers managed by the ToolHive operator. Secrets (OAuth tokens) are injected by ToolHive, not by our platform.
+- **vMCP aggregation**: The agent sees a single MCP endpoint with all tools namespaced. No per-tool configuration in the AgentConfig.
+- **Lightweight sandboxes**: Personal assistant workloads need minimal compute (1 CPU, 2Gi). No build tools, no large repos.
+- **Pi as agent runtime**: Pi's minimal core and extension model make it a good fit for non-coding agent tasks. Its RPC mode integrates cleanly with the SDK.
+- **Credential separation**: Google API credentials are managed by ToolHive. The Anthropic API key is managed by the credential proxy. Neither is visible to the agent.

--- a/examples/personal-assistant/manifests/agentconfig.yaml
+++ b/examples/personal-assistant/manifests/agentconfig.yaml
@@ -1,0 +1,33 @@
+apiVersion: factory.example.com/v1alpha1
+kind: AgentConfig
+metadata:
+  name: pi-assistant
+  namespace: assistant-ns
+spec:
+  agentType: pi
+  displayName: "Pi Personal Assistant"
+
+  sdk:
+    image: ghcr.io/rivet-dev/sandbox-agent:v0.4.2
+    port: 2468
+
+  bridge:
+    image: ghcr.io/example/factory-bridge:v0.1.0
+    port: 8080
+    healthCheck:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+
+  agentSettings:
+    contextFile: AGENTS.md
+
+  credentials:
+    - name: ANTHROPIC_API_KEY
+      secretRef:
+        name: anthropic-credentials
+        key: api-key
+      host: api.anthropic.com
+      header: x-api-key

--- a/examples/personal-assistant/manifests/pool.yaml
+++ b/examples/personal-assistant/manifests/pool.yaml
@@ -1,0 +1,42 @@
+apiVersion: factory.example.com/v1alpha1
+kind: Pool
+metadata:
+  name: assistant-pool
+  namespace: assistant-ns
+spec:
+  agentConfigRef:
+    name: pi-assistant
+
+  replicas:
+    min: 1
+    max: 3
+    idleTimeout: 10m
+    scaleUpThreshold: 0.8
+
+  sandboxTemplate:
+    resources:
+      requests:
+        cpu: "1"
+        memory: "2Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+
+    storage:
+      size: 10Gi
+      storageClassName: standard
+      reclaimPolicy: Delete    # No state worth preserving between tasks
+
+    # MCP tools via ToolHive VirtualMCPServer
+    mcpTools:
+      vmcpRef:
+        name: assistant-vmcp    # VirtualMCPServer in same namespace
+
+    networkPolicy:
+      egressRules:
+        # Anthropic API (for agent LLM calls)
+        - to: ["api.anthropic.com"]
+          ports: [443]
+        # Google APIs (accessed via MCP servers, but the vMCP proxy
+        # is cluster-internal — these rules are for the MCP server
+        # pods themselves, not the sandbox)

--- a/examples/personal-assistant/manifests/task.yaml
+++ b/examples/personal-assistant/manifests/task.yaml
@@ -1,0 +1,25 @@
+apiVersion: factory.example.com/v1alpha1
+kind: Task
+metadata:
+  name: schedule-followup
+  namespace: assistant-ns
+spec:
+  poolRef:
+    name: assistant-pool
+
+  prompt: |
+    You are a personal assistant with access to Google Calendar and Gmail.
+
+    1. Search Gmail for the email thread with subject containing "Q2 planning"
+       from the past week.
+    2. Identify all participants on that thread.
+    3. Check my calendar for available 1-hour slots tomorrow afternoon
+       (between 1pm and 5pm).
+    4. Create a calendar event titled "Q2 Planning Follow-up" at the first
+       available slot. Invite all participants from the email thread.
+    5. Draft a reply to the email thread letting everyone know about the meeting.
+
+    Summarize what you did when finished.
+
+  timeout: 10m
+  retries: 1

--- a/examples/personal-assistant/manifests/toolhive.yaml
+++ b/examples/personal-assistant/manifests/toolhive.yaml
@@ -1,0 +1,78 @@
+# Google Calendar MCP server managed by ToolHive
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: google-calendar
+  namespace: assistant-ns
+  labels:
+    toolhive.stacklok.com/group: assistant-tools
+spec:
+  image: ghcr.io/toolhive-mcp/google-calendar:latest
+  transport: sse
+  permissions:
+    network:
+      outbound:
+        allowedDomains:
+          - "*.googleapis.com"
+          - "oauth2.googleapis.com"
+  secretMappings:
+    - secretName: google-oauth-credentials
+      secretKey: client-id
+      envVar: GOOGLE_CLIENT_ID
+    - secretName: google-oauth-credentials
+      secretKey: client-secret
+      envVar: GOOGLE_CLIENT_SECRET
+    - secretName: google-oauth-credentials
+      secretKey: refresh-token
+      envVar: GOOGLE_REFRESH_TOKEN
+---
+# Gmail MCP server managed by ToolHive
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: gmail
+  namespace: assistant-ns
+  labels:
+    toolhive.stacklok.com/group: assistant-tools
+spec:
+  image: ghcr.io/toolhive-mcp/gmail:latest
+  transport: sse
+  permissions:
+    network:
+      outbound:
+        allowedDomains:
+          - "*.googleapis.com"
+          - "oauth2.googleapis.com"
+  secretMappings:
+    - secretName: google-oauth-credentials
+      secretKey: client-id
+      envVar: GOOGLE_CLIENT_ID
+    - secretName: google-oauth-credentials
+      secretKey: client-secret
+      envVar: GOOGLE_CLIENT_SECRET
+    - secretName: google-oauth-credentials
+      secretKey: refresh-token
+      envVar: GOOGLE_REFRESH_TOKEN
+---
+# Group the MCP servers together
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPGroup
+metadata:
+  name: assistant-tools
+  namespace: assistant-ns
+spec:
+  selector:
+    matchLabels:
+      toolhive.stacklok.com/group: assistant-tools
+---
+# Virtual MCP server aggregating both behind a single endpoint
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: VirtualMCPServer
+metadata:
+  name: assistant-vmcp
+  namespace: assistant-ns
+spec:
+  groupRef:
+    name: assistant-tools
+  # Tools are auto-namespaced: calendar_list_events, gmail_search_messages, etc.
+  toolNamespacing: true


### PR DESCRIPTION
## Summary
- Add `examples/` directory with two self-contained usage examples
- **Coding agent with K8s access**: Claude Code agent that builds, deploys, and troubleshoots apps in a target namespace. Shows ServiceAccount RBAC scoping, network policies for K8s API access, and stateful sandbox iteration.
- **Personal assistant**: Pi agent with Google Calendar and Gmail via ToolHive MCP servers. Shows VirtualMCPServer aggregation, tool namespacing, and credential separation between ToolHive and the credential proxy.

Each example includes:
- README with architecture diagram, use case walkthrough, and key design points
- Complete manifests (AgentConfig, Pool, Task, RBAC/ToolHive resources)

## Why these two examples
They demonstrate the platform's breadth — one is a coding agent with infrastructure access, the other is a non-coding personal assistant using MCP tools. Together they show the system isn't limited to software development.

## Test plan
- [ ] Review YAML manifests against CRD definitions in spec 04
- [ ] Verify ToolHive CRD shapes match ToolHive documentation
- [ ] Confirm RBAC in K8s example follows least-privilege principle

https://claude.ai/code/session_01JByrczUnBqBCnqwZ5RKizj