### PR TITLE
spec: add session-level permission gating and Session CRD

### DIFF
--- a/spec/04-control-plane.md
+++ b/spec/04-control-plane.md
@@ -149,6 +149,12 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 10
 
+  # Permission handling for runtime tool-approval prompts
+  permissionMode: bypass        # bypass | autoApprove | requireApproval
+  # bypass:          Set bypassPermissions on the agent session (no prompts)
+  # autoApprove:     Bridge auto-responds "allow" to every permission request
+  # requireApproval: Bridge publishes request to NATS and waits for external approval
+
   # Agent-specific settings
   agentSettings:
     contextFile: CLAUDE.md      # Which context file the agent reads
@@ -284,7 +290,7 @@ spec:
   retries: 1
 
 status:
-  phase: Running
+  phase: Running              # Pending | Running | WaitingForApproval | Succeeded | Failed | Cancelled
   sandboxRef:
     name: claude-code-pool-abc123
   sessionRef:
@@ -296,6 +302,95 @@ status:
     output: 8000
     cost: "0.42"
 ```
+
+The `WaitingForApproval` task phase is set when the underlying session enters `WaitingForApproval`. It is informational — the Task Controller does not act on it directly; it simply mirrors the session phase so that workflow-level consumers have visibility without reading Session CRs.
+
+### Session
+
+A Session represents a single agent conversation within a sandbox. The Session Controller creates sessions when a Task is assigned to a sandbox and manages them through completion.
+
+```yaml
+apiVersion: factory.example.com/v1alpha1
+kind: Session
+metadata:
+  name: session-xyz789
+  namespace: team-alpha
+  labels:
+    factory.example.com/task: implement-handlers
+    factory.example.com/sandbox: claude-code-pool-abc123
+spec:
+  sandboxRef:
+    name: claude-code-pool-abc123
+  taskRef:
+    name: implement-handlers
+  prompt: |
+    Implement the HTTP handlers based on the API spec.
+  contextFiles:
+    - path: /workspace/api-spec.yaml
+      configMapRef:
+        name: api-spec-artifact
+  timeout: 45m
+
+status:
+  phase: Active             # Pending | Active | WaitingForApproval | Completed | Failed | Cancelled
+  acpServerID: acp-abc123   # SDK ACP server identifier
+  startedAt: "2026-03-27T10:15:00Z"
+  lastEventAt: "2026-03-27T10:30:00Z"
+
+  # Present only when phase is WaitingForApproval
+  pendingApproval:
+    id: "perm-001"          # Unique ID for this permission request
+    toolName: Bash           # Tool the agent wants to execute
+    title: "mkdir -p /workspace/output"  # Human-readable summary
+    requestedAt: "2026-03-27T10:30:00Z"
+    # Full request details (arguments, context) are in NATS, not etcd.
+    # Use the SSE stream or NATS subject to get the complete request.
+
+  tokenUsage:
+    input: 15000
+    output: 8000
+    cost: "0.42"
+  conditions:
+    - type: Ready
+      status: "True"
+    - type: AgentHealthy
+      status: "True"
+```
+
+#### Session Phases
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | Session CR created, bridge not yet connected |
+| `Active` | Agent is executing, events are streaming |
+| `WaitingForApproval` | Agent blocked on a permission request (only when `permissionMode: requireApproval`) |
+| `Completed` | Agent finished successfully |
+| `Failed` | Agent errored or timed out |
+| `Cancelled` | Session was cancelled by the user or workflow controller |
+
+The `WaitingForApproval` phase is only reachable when the AgentConfig's `permissionMode` is `requireApproval`. In `bypass` mode, the agent never emits permission requests. In `autoApprove` mode, the bridge responds immediately and the session stays `Active`.
+
+#### Permission Request Lifecycle
+
+When `permissionMode: requireApproval`:
+
+1. The SDK agent emits a `session/request_permission` ACP JSON-RPC request.
+2. The bridge normalizes it and publishes to NATS (`events.{tenant}.sessions.{session-id}`).
+3. The bridge publishes a lifecycle event: `session.permission_requested`.
+4. The Session Controller updates the Session CR: phase → `WaitingForApproval`, populates `status.pendingApproval`.
+5. The Task Controller propagates the phase to the Task CR: phase → `WaitingForApproval`.
+6. The API server streams the permission details to external clients via SSE (sourced from NATS, not the CR).
+
+**Approval response:**
+
+1. An external client calls `POST /v1/sessions/{id}/permissions/{permissionId}` with `allow` or `deny`.
+2. The API server publishes the decision to a NATS reply subject.
+3. The bridge receives the decision, sends a JSON-RPC response to the SDK.
+4. The bridge publishes a lifecycle event: `session.permission_responded`.
+5. The Session Controller updates the Session CR: phase → `Active`, clears `status.pendingApproval`.
+6. The Task Controller propagates the phase back to `Running`.
+
+**Design principle:** Only summary data (`toolName`, `title`, `requestedAt`) is stored in etcd via the Session CR. Full permission request payloads (tool arguments, context, rendered diffs) flow through NATS and are served via SSE. This keeps etcd writes low-frequency — one write on request, one on response.
 
 ## Operator Behaviors
 
@@ -339,7 +434,13 @@ status:
 
 2. **On event received**: Publish to NATS stream `sessions.<session-id>`. Update Session CR status with latest event summary.
 
-3. **On session complete**: Set Session CR status to final state. Record token usage and cost metadata.
+3. **On `session.permission_requested` lifecycle event** (only when `permissionMode: requireApproval`): Set Session CR phase to `WaitingForApproval`. Populate `status.pendingApproval` with summary fields (`id`, `toolName`, `title`, `requestedAt`). This is a single etcd write — the full request payload stays in NATS.
+
+4. **On `session.permission_responded` lifecycle event**: Clear `status.pendingApproval`. Set Session CR phase back to `Active`.
+
+5. **On session complete**: Set Session CR status to final state. Record token usage and cost metadata.
+
+**Important:** The Session Controller subscribes only to **lifecycle events** (started, completed, failed, permission_requested, permission_responded) — not the high-frequency tool call and output events. This keeps etcd write volume bounded by session state transitions, not agent activity.
 
 ## API Server
 
@@ -356,8 +457,28 @@ The API server is a Go service that provides a client-facing interface over the 
 | POST | `/v1/tasks` | Submit a standalone task |
 | GET | `/v1/tasks/{id}` | Get task status |
 | GET | `/v1/tasks/{id}/events` | Stream task events (SSE) |
+| GET | `/v1/sessions/{id}` | Get session status |
+| GET | `/v1/sessions/{id}/events` | Stream session events (SSE) |
+| POST | `/v1/sessions/{id}/permissions/{permissionId}` | Approve or deny a permission request |
 | GET | `/v1/pools` | List pools |
 | GET | `/v1/pools/{id}` | Get pool status |
 | PATCH | `/v1/pools/{id}/scale` | Adjust pool scaling |
+
+#### Permission Approval Endpoint
+
+```
+POST /v1/sessions/{id}/permissions/{permissionId}
+Content-Type: application/json
+
+{
+  "decision": "allow",        // "allow" or "deny"
+  "remember": "session"       // optional: "once" | "session" | "always"
+}
+```
+
+- `decision`: Whether to allow or deny the tool execution.
+- `remember`: Scope of the decision. `once` applies to this request only. `session` auto-applies the same decision for the same tool for the rest of the session. `always` persists to future sessions (stored in AgentConfig annotation).
+
+The API server publishes the decision to the NATS reply subject `permissions.{session-id}.{permissionId}`. The bridge subscribes to this subject and forwards the response to the SDK as a JSON-RPC reply. The SSE stream on `/v1/sessions/{id}/events` includes permission request and response events, so clients can build interactive approval UIs.
 
 All endpoints require authentication (bearer token or mTLS) and respect Kubernetes RBAC via impersonation.

--- a/spec/06-agent-adapter.md
+++ b/spec/06-agent-adapter.md
@@ -209,6 +209,10 @@ const (
     EventShellExec   EventType = "shell.exec"
     EventShellOutput EventType = "shell.output"
 
+    // Permission gating (see spec/04 Session CR for lifecycle details)
+    EventPermissionRequested  EventType = "session.permission_requested"
+    EventPermissionResponded  EventType = "session.permission_responded"
+
     // Token tracking
     EventTokenUsage EventType = "token.usage"
 
@@ -218,6 +222,96 @@ const (
 ```
 
 We retain the `Raw` field so we can always fall back to the SDK's native event format for debugging or agent-specific analysis.
+
+### Permission Event Data
+
+Permission events carry structured data payloads:
+
+```go
+// PermissionRequestData is the Data payload for EventPermissionRequested.
+type PermissionRequestData struct {
+    PermissionID string `json:"permissionId"` // Unique ID for correlation
+    ToolName     string `json:"toolName"`     // e.g. "Bash", "Write", "Edit"
+    Title        string `json:"title"`        // Human-readable summary
+    // Full tool arguments (command text, file contents, etc.) are included
+    // so SSE consumers can render an approval UI without polling etcd.
+    Arguments    json.RawMessage `json:"arguments"`
+}
+
+// PermissionResponseData is the Data payload for EventPermissionResponded.
+type PermissionResponseData struct {
+    PermissionID string `json:"permissionId"`
+    Decision     string `json:"decision"`  // "allow" or "deny"
+    Remember     string `json:"remember"`  // "once", "session", or "always"
+    RespondedBy  string `json:"respondedBy,omitempty"` // user or "bridge:autoApprove"
+}
+```
+
+## Permission Handling in the Bridge
+
+The bridge sidecar handles runtime permission requests differently based on the AgentConfig's `permissionMode`:
+
+### Mode: `bypass`
+
+The bridge calls `session/set_config_option` with `bypassPermissions: true` immediately after creating the ACP session. The agent never emits permission requests. This is the default.
+
+### Mode: `autoApprove`
+
+The bridge does **not** set `bypassPermissions`. When the SDK's SSE stream contains a `session/request_permission` JSON-RPC request:
+
+1. The bridge immediately responds with `allow_always` via `POST /v1/acp/{server_id}`.
+2. The bridge publishes an `EventPermissionRequested` event followed by an `EventPermissionResponded` event to NATS (for audit trail).
+3. The session stays `Active` — no phase change, no etcd write beyond normal event summaries.
+
+### Mode: `requireApproval`
+
+When the SSE stream contains a `session/request_permission` JSON-RPC request:
+
+1. The bridge publishes an `EventPermissionRequested` event to NATS with full request details.
+2. The bridge subscribes to the NATS reply subject `permissions.{session-id}.{permissionId}` and **blocks** (with a configurable timeout, default 1h).
+3. When a response arrives on the reply subject, the bridge sends the corresponding JSON-RPC response to the SDK via `POST /v1/acp/{server_id}`.
+4. The bridge publishes an `EventPermissionResponded` event to NATS.
+5. If the timeout expires with no response, the bridge responds with `deny` and publishes a timeout event.
+
+```go
+// handlePermissionRequest processes a permission request from the SDK.
+func (b *Bridge) handlePermissionRequest(ctx context.Context, sessionID string, req ACPPermissionRequest) error {
+    permID := uuid.NewString()
+
+    // Publish request event to NATS
+    b.publishEvent(ctx, sessionID, Event{
+        Type: EventPermissionRequested,
+        Data: PermissionRequestData{
+            PermissionID: permID,
+            ToolName:     req.ToolName,
+            Title:        req.Title,
+            Arguments:    req.Arguments,
+        },
+    })
+
+    // Wait for approval on reply subject
+    replySubject := fmt.Sprintf("permissions.%s.%s", sessionID, permID)
+    msg, err := b.natsConn.RequestWithContext(ctx, replySubject, nil)
+    if err != nil {
+        // Timeout or context cancelled — deny by default
+        b.respondToSDK(ctx, sessionID, req.ID, "deny")
+        return err
+    }
+
+    var decision PermissionResponseData
+    json.Unmarshal(msg.Data, &decision)
+
+    // Forward decision to SDK
+    b.respondToSDK(ctx, sessionID, req.ID, decision.Decision)
+
+    // Publish response event
+    b.publishEvent(ctx, sessionID, Event{
+        Type: EventPermissionResponded,
+        Data: decision,
+    })
+    return nil
+}
+```
 
 ## Session Lifecycle
 
@@ -249,6 +343,33 @@ Session Controller                Bridge Sidecar              Sandbox Agent SDK
       │  Session complete event        │                              │
       │◄───────────────────────────────┤                              │
       │  Update Session CR status      │                              │
+```
+
+### Permission Request Flow (requireApproval mode)
+
+```
+External Client         API Server         NATS          Bridge Sidecar          SDK
+      │                     │               │                  │                   │
+      │                     │               │                  │  permission_request│
+      │                     │               │                  │◄──────────────────┤
+      │                     │               │  publish event   │                   │
+      │                     │               │◄─────────────────┤                   │
+      │                     │               │  (subscribe to   │                   │
+      │                     │               │   reply subject)  │                   │
+      │                     │  SSE event    │                  │                   │
+      │  SSE: permission    │◄──────────────┤                  │                   │
+      │  requested          │               │                  │                   │
+      │◄────────────────────┤               │                  │                   │
+      │                     │               │                  │                   │
+      │  POST /permissions  │               │                  │                   │
+      │  {decision: allow}  │               │                  │                   │
+      ├────────────────────►│  publish to   │                  │                   │
+      │                     │  reply subject│                  │                   │
+      │                     ├──────────────►│  deliver reply   │                   │
+      │                     │               ├─────────────────►│  JSON-RPC response│
+      │                     │               │                  ├──────────────────►│
+      │                     │               │                  │  agent resumes    │
+      │                     │               │                  │                   │
 ```
 
 ## Credential Injection
@@ -306,6 +427,9 @@ spec:
   bridge:
     image: ghcr.io/example/factory-bridge:v0.1.0
     port: 8080
+
+  # Permission handling (see "Permission Handling in the Bridge" above)
+  permissionMode: bypass        # bypass | autoApprove | requireApproval
 
   # Agent-specific configuration
   agentSettings:

--- a/spec/07-orchestration-engine.md
+++ b/spec/07-orchestration-engine.md
@@ -244,6 +244,22 @@ tasks:
 
 Approval tasks don't consume a sandbox. They create a notification (webhook, email, Slack) and wait for an explicit approval via the API.
 
+#### Workflow-Level vs. Session-Level Approval
+
+The system supports two distinct approval mechanisms at different granularities:
+
+| | Workflow-Level Approval | Session-Level Permission Gating |
+|---|---|---|
+| **Scope** | Between tasks in a DAG | During a single agent session |
+| **Granularity** | Coarse — gates entire workflow stages | Fine — individual tool executions |
+| **Trigger** | `type: approval` task in the DAG | Agent emits `session/request_permission` |
+| **Blocks** | Downstream tasks from starting | The agent from executing a specific tool |
+| **Configuration** | Workflow spec (`tasks[].type`) | AgentConfig (`permissionMode`) |
+| **Response path** | API → Task Controller → workflow resumes | API → NATS → Bridge → SDK → agent resumes |
+| **Spec reference** | This document (07) | [04 - Control Plane](04-control-plane.md) (Session CR), [06 - Agent Adapter](06-agent-adapter.md) (Bridge handling) |
+
+These mechanisms are **complementary**. A workflow can use approval tasks to gate stages (e.g., "review before deploy") while individual sessions within those stages use `requireApproval` to gate tool execution (e.g., "approve before running `rm -rf`"). They do not overlap — approval tasks are DAG-level concerns; permission gating is session-level.
+
 ## Workflow Templates
 
 Reusable workflow patterns can be defined as templates:

--- a/spec/08-observability-and-events.md
+++ b/spec/08-observability-and-events.md
@@ -30,10 +30,13 @@ NATS JetStream
 Events are published to NATS JetStream with subject-based routing:
 
 ```
-events.{tenant}.sessions.{session-id}    # Per-session events
-events.{tenant}.tasks.{task-id}          # Task lifecycle events
-events.{tenant}.workflows.{workflow-id}  # Workflow lifecycle events
+events.{tenant}.sessions.{session-id}           # Per-session events (all types)
+events.{tenant}.tasks.{task-id}                 # Task lifecycle events
+events.{tenant}.workflows.{workflow-id}         # Workflow lifecycle events
+permissions.{session-id}.{permission-id}        # Permission approval reply subjects
 ```
+
+The `permissions.*` subjects use NATS request/reply for synchronous approval routing. The bridge publishes a permission request event to the session subject and subscribes to the corresponding `permissions.*` reply subject. The API server publishes decisions to the reply subject when an external client responds. These subjects are ephemeral — they exist only while a permission request is pending.
 
 Stream configuration:
 - **Retention**: Limits-based (max age: 30 days, max bytes: configurable per tenant)
@@ -45,11 +48,13 @@ Stream configuration:
 
 | Consumer | Purpose | Delivery |
 |----------|---------|----------|
-| `session-controller` | Updates Session CR status | Queue group (load-balanced) |
+| `session-controller` | Updates Session CR status (lifecycle events only) | Queue group (load-balanced) |
 | `event-store` | Persists events to long-term storage | Single consumer |
 | `otel-exporter` | Exports metrics and traces to OTel Collector | Queue group |
 | `webhook-dispatcher` | Fires external webhooks on key events | Queue group |
 | `api-streamer` | Serves SSE to API clients | Per-subscription |
+
+The `session-controller` consumer filters for lifecycle event types only: `session.started`, `session.completed`, `session.failed`, `session.permission_requested`, `session.permission_responded`. High-frequency events (`tool.call`, `tool.result`, `shell.exec`, etc.) are consumed by the other groups but **not** by the session controller — this keeps etcd writes bounded by state transitions, not agent activity.
 
 ## Metrics
 
@@ -83,6 +88,14 @@ All metrics are exported via OpenTelemetry and scraped by Prometheus.
 | `factory_tool_duration_seconds` | Histogram | agent_type, tool | Tool execution time |
 | `factory_tool_errors_total` | Counter | agent_type, tool | Failed tool invocations |
 | `factory_agent_errors_total` | Counter | agent_type, error_type | Agent-level errors |
+
+### Permission Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `factory_permission_requests_total` | Counter | agent_type, tool, decision | Permission requests by outcome (allow/deny/timeout) |
+| `factory_permission_latency_seconds` | Histogram | agent_type, tool | Time from permission request to response |
+| `factory_permission_auto_approved_total` | Counter | agent_type, tool | Permissions auto-approved by the bridge (autoApprove mode) |
 
 ## Distributed Tracing
 
@@ -216,6 +229,7 @@ spec:
     - workflow.completed
     - workflow.failed
     - task.failed
+    - session.permission_requested   # Notify when an agent needs approval
   endpoint: https://hooks.slack.com/services/...
   secret:
     secretRef:


### PR DESCRIPTION
## Summary

- **Closes a gap** in the architecture spec: only workflow-level approval tasks (coarse DAG gates) were defined, but fine-grained runtime permission requests from agents during execution were not addressed
- **Defines the Session CRD** (previously referenced but never specified) with full spec, status, phases, and `pendingApproval` field
- **Adds `permissionMode`** to AgentConfig (`bypass | autoApprove | requireApproval`) and documents the bridge's handling of each mode
- **Adds permission approval API endpoint**, NATS reply subjects, permission metrics, and webhook events

### Documents changed

| Spec | What was added |
|------|---------------|
| 04 — Control Plane | Session CRD, `permissionMode` on AgentConfig, `WaitingForApproval` phase, permission API endpoint, Session Controller updates |
| 06 — Agent Adapter | Permission event types + data schemas, bridge handling for all 3 modes (with Go code), permission request flow diagram |
| 07 — Orchestration | Comparison table: workflow-level vs session-level approval |
| 08 — Observability | NATS `permissions.*` reply subjects, `session-controller` lifecycle filtering, permission metrics, webhook event |

Ref: #13

## Test plan

- [ ] Review each spec document for internal consistency
- [ ] Verify the Session CRD fields align with the bridge Go code in spec/06
- [ ] Verify the NATS subject naming is consistent across spec/04, spec/06, and spec/08
- [ ] Confirm the permission request lifecycle in spec/04 matches the sequence diagram in spec/06

🤖 Generated with [Claude Code](https://claude.com/claude-code)