### PR TITLE
fix: .gitignore and concurrent envtest timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,10 @@ go.work.sum
 # Build output
 bin/
 
+# Development and testing artifacts
+logs/
+kubectl
+sandbox-agent/
+
 # Local Claude Code settings
 .claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ build: ## Build all binaries
 
 .PHONY: test
 test: ## Run unit tests
-	go test ./... -race
+	go test -p 1 ./... -race
 
 .PHONY: test-verbose
 test-verbose: ## Run unit tests with verbose output
-	go test ./... -race -v -coverprofile=coverage.out
+	go test -p 1 ./... -race -v -coverprofile=coverage.out
 
 ##@ Lint
 


### PR DESCRIPTION
## Summary

- **`.gitignore`**: Add `logs/`, `kubectl`, `sandbox-agent/` — development artifacts that were cluttering `git status`
- **`Makefile`**: Add `-p 1` to `go test` so packages run sequentially, fixing intermittent 10-minute timeouts when multiple envtest instances (controller + testharness) compete for resources under the race detector

`make all` now passes reliably.

Closes #19, closes #26

## Test plan

- [x] `make all` passes: generate, build, lint (0 issues), all tests pass sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)