### PR TITLE
fix: inject credentials into SDK container for agent authentication

### DIFF
--- a/internal/controller/sandbox_controller.go
+++ b/internal/controller/sandbox_controller.go
@@ -600,9 +600,11 @@ func (r *SandboxReconciler) buildPod(sandbox *factoryv1alpha1.Sandbox, pool *fac
 		}
 	}
 
-	// Inject credential env vars into bridge container
+	// Inject credential env vars into both bridge and SDK containers.
+	// The bridge needs them for the credential proxy; the SDK container
+	// needs them because the agent process requires API keys directly.
 	for _, cred := range agentConfig.Spec.Credentials {
-		bridgeContainer.Env = append(bridgeContainer.Env, corev1.EnvVar{
+		envVar := corev1.EnvVar{
 			Name: cred.Name,
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
@@ -610,7 +612,9 @@ func (r *SandboxReconciler) buildPod(sandbox *factoryv1alpha1.Sandbox, pool *fac
 					Key:                  cred.SecretRef.Key,
 				},
 			},
-		})
+		}
+		bridgeContainer.Env = append(bridgeContainer.Env, envVar)
+		sdkContainer.Env = append(sdkContainer.Env, envVar)
 	}
 
 	return &corev1.Pod{


### PR DESCRIPTION
## Summary

The sandbox controller was only injecting credential env vars (e.g., `ANTHROPIC_API_KEY`) into the bridge sidecar container. The SDK container — where the agent process actually runs — did not receive them, causing `Invalid API key` errors on every task.

One-line fix: credentials are now injected into both containers.

Closes #14

## Test plan

- [x] Deployed to kind cluster, verified SDK container has `ANTHROPIC_API_KEY` env var
- [x] Build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)