### PR TITLE
chore: add /deploy and /spec-audit custom skills

### DIFF
--- a/.claude/skills/deploy.md
+++ b/.claude/skills/deploy.md
@@ -1,0 +1,22 @@
+---
+name: deploy
+description: Build, load, and deploy the latest code to the kind cluster
+user-invocable: true
+---
+
+Deploy the latest code to the kind cluster named "factory". Run these steps in order, stopping on any failure:
+
+1. `make docker-build` — build all three container images
+2. `kind load docker-image software-factory-controller-manager:latest software-factory-apiserver:latest software-factory-bridge:latest --name factory` — load into kind
+3. `kubectl apply -k config/default/` — apply latest CRDs and manifests
+4. `kubectl rollout restart deployment/controller-manager deployment/apiserver -n factory-system` — restart deployments to pick up new images
+5. `kubectl rollout status deployment/controller-manager deployment/apiserver -n factory-system --timeout=120s` — wait for rollout
+
+If the user said "fresh" or "clean", also run:
+6. `kubectl delete sandbox --all -n demo` — force sandbox recreation with latest pod spec
+7. Wait for new sandboxes to become Ready
+
+Finally, show the cluster state:
+- `kubectl get pods -n factory-system`
+- `kubectl get pods -n demo`
+- `kubectl get sandbox -n demo`

--- a/.claude/skills/spec-audit.md
+++ b/.claude/skills/spec-audit.md
@@ -1,0 +1,29 @@
+---
+name: spec-audit
+description: Audit spec documents against implementation for a given topic
+user-invocable: true
+---
+
+Audit the architecture spec against the current implementation for the topic the user provides (e.g., "session completion", "credential injection", "permission gating").
+
+Steps:
+
+1. Read `spec/README.md` to identify which spec documents are relevant to the topic.
+2. Read each relevant spec document thoroughly. Key documents:
+   - `spec/04-control-plane.md` — CRDs, controller behaviors, API endpoints
+   - `spec/06-agent-adapter.md` — Bridge sidecar, SDK integration, event normalization
+   - `spec/07-orchestration-engine.md` — Workflow DAG, task execution, approval
+   - `spec/08-observability-and-events.md` — NATS streams, metrics, webhooks
+   - `spec/09-security-model.md` — Isolation, secrets, RBAC, network policies
+3. Read the corresponding implementation files (controllers, bridge, API server, event types).
+4. For each area, report:
+
+| Area | Spec Says | Code Does | Gap |
+|------|-----------|-----------|-----|
+| ... | ... | ... | ... |
+
+5. Separate the gaps into two categories:
+   - **User-facing gaps** — things that affect what a user sees or can do
+   - **Internal gaps** — implementation details, optimizations, or future work
+
+6. For each user-facing gap, assess severity: does it block usage, degrade the experience, or is it a missing nice-to-have?


### PR DESCRIPTION
## Summary

Two reusable slash commands for workflows that came up repeatedly during development:

- **`/deploy`** — builds Docker images, loads into kind cluster "factory", applies manifests, restarts deployments, waits for rollout, shows status. Say "fresh" to also recreate sandboxes.
- **`/spec-audit <topic>`** — reads relevant spec documents for a topic, compares against implementation, reports a structured gap table (user-facing vs internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)