### PR TITLE
fix: propagate prompt failures to session status

### DIFF
--- a/internal/bridge/server.go
+++ b/internal/bridge/server.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/alexbrand/software-factory/pkg/events"
 )
 
 // Server exposes HTTP endpoints for the Session Controller to call.
@@ -103,6 +107,7 @@ func (s *Server) handleStartSession(w http.ResponseWriter, r *http.Request) {
 		Prompt:         req.Prompt,
 		ContextFiles:   ctxFiles,
 		PermissionMode: req.PermissionMode,
+		OnPromptError:  s.makePromptErrorHandler(),
 	}
 
 	// Create a callback factory that wires up event forwarding and permission
@@ -151,6 +156,34 @@ func (s *Server) makeEventCallbackFactory(permissionMode string) EventCallbackFa
 				s.eventForwarder.ForwardEvent(context.Background(), serverID, event)
 			}
 		}
+	}
+}
+
+// makePromptErrorHandler returns a callback that publishes session.failed
+// when the prompt RPC fails (e.g., invalid API key, model error).
+func (s *Server) makePromptErrorHandler() func(serverID string, err error) {
+	return func(serverID string, promptErr error) {
+		if s.eventForwarder == nil || s.eventForwarder.publisher == nil {
+			return
+		}
+
+		dataBytes, _ := json.Marshal(events.SessionFailedData{
+			Reason: promptErr.Error(),
+		})
+
+		event := events.Event{
+			ID:        uuid.New().String(),
+			SessionID: serverID,
+			Timestamp: time.Now().UTC(),
+			Type:      events.EventSessionFailed,
+			Data:      dataBytes,
+		}
+
+		_ = s.eventForwarder.publisher.Publish(
+			context.Background(),
+			s.eventForwarder.namespace,
+			event,
+		)
 	}
 }
 

--- a/internal/bridge/session.go
+++ b/internal/bridge/session.go
@@ -38,6 +38,10 @@ type StartSessionConfig struct {
 	ContextFiles   []ContextFile
 	WorkDir        string
 	PermissionMode string
+	// OnPromptError is called when the prompt RPC fails. This allows the
+	// bridge server to publish a session.failed event on prompt errors
+	// (e.g., invalid API key) instead of silently hanging.
+	OnPromptError func(serverID string, err error)
 }
 
 // ContextFile represents a file to write to the sandbox before starting the session.
@@ -87,11 +91,13 @@ func (m *SessionManager) StartSession(ctx context.Context, cfg StartSessionConfi
 
 	// Send the prompt in a goroutine. The ACP session/prompt RPC blocks until
 	// the agent finishes, which can take minutes. We return immediately so the
-	// bridge HTTP handler doesn't time out. Prompt errors are logged and will
-	// surface as a session timeout to the task controller.
+	// bridge HTTP handler doesn't time out.
 	go func() {
 		if err := m.sdk.SendACPMessage(context.Background(), serverID, cfg.Prompt); err != nil {
 			m.logger.Error("failed to send prompt", "serverID", serverID, "error", err)
+			if cfg.OnPromptError != nil {
+				cfg.OnPromptError(serverID, err)
+			}
 		}
 	}()
 

--- a/internal/testharness/fakesdk.go
+++ b/internal/testharness/fakesdk.go
@@ -47,9 +47,18 @@ type SessionBehavior struct {
 	// PromptDelay makes session/prompt block for this duration.
 	PromptDelay time.Duration
 
+	// PromptError, if non-nil, makes session/prompt return this JSON-RPC error.
+	PromptError *JSONRPCError
+
 	// Events are SSE-formatted strings pushed to the stream on session start.
 	// Each should be a complete SSE block, e.g. "event: message\ndata: {...}\n\n"
 	Events []string
+}
+
+// JSONRPCError represents a JSON-RPC error for fake responses.
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 // FakeSessionInfo exposes session state for test assertions.
@@ -291,6 +300,7 @@ func (f *FakeSDK) handleACPPost(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		sess := f.sessions[serverID]
 		delay := f.behavior.PromptDelay
+		promptErr := f.behavior.PromptError
 		if sess != nil && len(p.Prompt) > 0 {
 			sess.prompts = append(sess.prompts, p.Prompt[0].Text)
 		}
@@ -298,6 +308,16 @@ func (f *FakeSDK) handleACPPost(w http.ResponseWriter, r *http.Request) {
 
 		if delay > 0 {
 			time.Sleep(delay)
+		}
+
+		if promptErr != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{
+				JSONRPC: "2.0", ID: rpcReq.ID,
+				Error: &jsonRPCError{Code: promptErr.Code, Message: promptErr.Message},
+			})
+			return
 		}
 
 		writeRPCResult(w, rpcReq.ID, `{"stopReason":"end_turn"}`)

--- a/internal/testharness/prompt_failure_test.go
+++ b/internal/testharness/prompt_failure_test.go
@@ -12,10 +12,14 @@ import (
 	"github.com/alexbrand/software-factory/internal/testharness"
 )
 
-// TestPromptFailure_PropagatesSessionFailed tests that when the agent prompt
-// RPC fails (e.g., invalid API key), the session moves to Failed with
-// failureReason=AgentError instead of hanging in Active until timeout.
-func TestPromptFailure_PropagatesSessionFailed(t *testing.T) {
+// TestPromptFailure tests the user experience when the agent fails at startup
+// (e.g., invalid API key). The user should see the task fail quickly with a
+// clear reason — not hang in Running for an hour.
+//
+// This test exercises the full signal path:
+//   SDK returns error → bridge publishes session.failed → controller updates
+//   Session CR → task controller reads session phase → Task CR moves to Failed
+func TestPromptFailure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -34,7 +38,7 @@ func TestPromptFailure_PropagatesSessionFailed(t *testing.T) {
 		},
 	})
 
-	// Setup: AgentConfig + Pool + wait for sandbox.
+	// Setup: AgentConfig + Pool + wait for a ready sandbox with pod IP.
 	agentCfg := &factoryv1alpha1.AgentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "claude", Namespace: "prompt-fail-test"},
 		Spec: factoryv1alpha1.AgentConfigSpec{
@@ -70,38 +74,73 @@ func TestPromptFailure_PropagatesSessionFailed(t *testing.T) {
 	})
 	h.SetPodIP(ctx, "prompt-fail-test", sb.Status.PodName, "10.0.0.5")
 
-	// Create session.
+	// Create a Task and Session directly (simulating the task controller's
+	// sandbox-claim → session-create flow). This avoids races with the sandbox
+	// controller in envtest while still testing the failure propagation path.
+	task := &factoryv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-key-task",
+			Namespace: "prompt-fail-test",
+		},
+		Spec: factoryv1alpha1.TaskSpec{
+			PoolRef: factoryv1alpha1.LocalObjectReference{Name: "prompt-fail-pool"},
+			Prompt:  "this will fail because the API key is invalid",
+		},
+	}
+	if err := h.K8sClient().Create(ctx, task); err != nil {
+		t.Fatalf("creating task: %v", err)
+	}
+
+	// Set task to Running with sandbox and session refs (as the task controller would).
+	now := metav1.Now()
+	task.Status.Phase = factoryv1alpha1.TaskPhaseRunning
+	task.Status.SandboxRef = &factoryv1alpha1.LocalObjectReference{Name: sb.Name}
+	task.Status.SessionRef = &factoryv1alpha1.LocalObjectReference{Name: "bad-key-session"}
+	task.Status.StartedAt = &now
+	task.Status.Attempts = 1
+	if err := h.K8sClient().Status().Update(ctx, task); err != nil {
+		t.Fatalf("updating task status: %v", err)
+	}
+
+	// Create the session (as the task controller would).
 	session := &factoryv1alpha1.Session{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "prompt-fail-session",
+			Name:      "bad-key-session",
 			Namespace: "prompt-fail-test",
 		},
 		Spec: factoryv1alpha1.SessionSpec{
 			SandboxRef: factoryv1alpha1.LocalObjectReference{Name: sb.Name},
 			AgentType:  "claude-code",
-			Prompt:     "this will fail",
+			Prompt:     "this will fail because the API key is invalid",
 		},
 	}
 	if err := h.K8sClient().Create(ctx, session); err != nil {
 		t.Fatalf("creating session: %v", err)
 	}
 
-	// The session should move to Failed quickly (not hang in Active for 1h).
-	t.Run("session enters Failed", func(t *testing.T) {
+	// === ASSERT: Session moves to Failed quickly (via NATS event from bridge) ===
+	t.Run("session fails with AgentError", func(t *testing.T) {
 		testharness.WaitFor(t, 15*time.Second, 500*time.Millisecond, func() bool {
 			var s factoryv1alpha1.Session
 			err := h.K8sClient().Get(ctx, client.ObjectKeyFromObject(session), &s)
 			return err == nil && s.Status.Phase == factoryv1alpha1.SessionPhaseFailed
 		})
-	})
 
-	t.Run("failureReason is AgentError", func(t *testing.T) {
 		var s factoryv1alpha1.Session
 		if err := h.K8sClient().Get(ctx, client.ObjectKeyFromObject(session), &s); err != nil {
 			t.Fatalf("getting session: %v", err)
 		}
 		if s.Status.FailureReason != factoryv1alpha1.FailureReasonAgentError {
-			t.Errorf("expected failureReason 'AgentError', got %q", s.Status.FailureReason)
+			t.Errorf("expected failureReason AgentError, got %q", s.Status.FailureReason)
 		}
+	})
+
+	// === ASSERT: Task propagates the failure (via task controller polling session) ===
+	t.Run("task fails via API", func(t *testing.T) {
+		api := h.APIClient()
+		testharness.WaitFor(t, 30*time.Second, 500*time.Millisecond, func() bool {
+			got, getErr := api.GetTask("bad-key-task")
+			return getErr == nil && got.Phase == "Failed"
+		})
 	})
 }

--- a/internal/testharness/prompt_failure_test.go
+++ b/internal/testharness/prompt_failure_test.go
@@ -1,0 +1,107 @@
+package testharness_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	factoryv1alpha1 "github.com/alexbrand/software-factory/api/v1alpha1"
+	"github.com/alexbrand/software-factory/internal/testharness"
+)
+
+// TestPromptFailure_PropagatesSessionFailed tests that when the agent prompt
+// RPC fails (e.g., invalid API key), the session moves to Failed with
+// failureReason=AgentError instead of hanging in Active until timeout.
+func TestPromptFailure_PropagatesSessionFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	h := testharness.New(t, testharness.WithNamespace("prompt-fail-test"))
+	h.Start()
+
+	ctx := context.Background()
+	h.CreateNamespace(ctx, "prompt-fail-test")
+
+	// Configure the fake SDK to return an error on session/prompt.
+	h.FakeSDK().SetBehavior(testharness.SessionBehavior{
+		PromptError: &testharness.JSONRPCError{
+			Code:    -32603,
+			Message: "Internal error: Invalid API key",
+		},
+	})
+
+	// Setup: AgentConfig + Pool + wait for sandbox.
+	agentCfg := &factoryv1alpha1.AgentConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "claude", Namespace: "prompt-fail-test"},
+		Spec: factoryv1alpha1.AgentConfigSpec{
+			AgentType: "claude-code",
+			SDK:       factoryv1alpha1.SDKConfig{Image: "sdk:latest"},
+			Bridge:    factoryv1alpha1.BridgeConfig{Image: "bridge:latest"},
+		},
+	}
+	if err := h.K8sClient().Create(ctx, agentCfg); err != nil {
+		t.Fatalf("creating agent config: %v", err)
+	}
+
+	pool := &factoryv1alpha1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: "prompt-fail-pool", Namespace: "prompt-fail-test"},
+		Spec: factoryv1alpha1.PoolSpec{
+			AgentConfigRef: factoryv1alpha1.LocalObjectReference{Name: "claude"},
+			Replicas:       factoryv1alpha1.ReplicasConfig{Min: 1, Max: 5},
+		},
+	}
+	if err := h.K8sClient().Create(ctx, pool); err != nil {
+		t.Fatalf("creating pool: %v", err)
+	}
+
+	var sb factoryv1alpha1.Sandbox
+	testharness.WaitFor(t, 30*time.Second, 500*time.Millisecond, func() bool {
+		var sbList factoryv1alpha1.SandboxList
+		_ = h.K8sClient().List(ctx, &sbList, client.InNamespace("prompt-fail-test"))
+		if len(sbList.Items) == 0 {
+			return false
+		}
+		sb = sbList.Items[0]
+		return sb.Status.PodName != ""
+	})
+	h.SetPodIP(ctx, "prompt-fail-test", sb.Status.PodName, "10.0.0.5")
+
+	// Create session.
+	session := &factoryv1alpha1.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prompt-fail-session",
+			Namespace: "prompt-fail-test",
+		},
+		Spec: factoryv1alpha1.SessionSpec{
+			SandboxRef: factoryv1alpha1.LocalObjectReference{Name: sb.Name},
+			AgentType:  "claude-code",
+			Prompt:     "this will fail",
+		},
+	}
+	if err := h.K8sClient().Create(ctx, session); err != nil {
+		t.Fatalf("creating session: %v", err)
+	}
+
+	// The session should move to Failed quickly (not hang in Active for 1h).
+	t.Run("session enters Failed", func(t *testing.T) {
+		testharness.WaitFor(t, 15*time.Second, 500*time.Millisecond, func() bool {
+			var s factoryv1alpha1.Session
+			err := h.K8sClient().Get(ctx, client.ObjectKeyFromObject(session), &s)
+			return err == nil && s.Status.Phase == factoryv1alpha1.SessionPhaseFailed
+		})
+	})
+
+	t.Run("failureReason is AgentError", func(t *testing.T) {
+		var s factoryv1alpha1.Session
+		if err := h.K8sClient().Get(ctx, client.ObjectKeyFromObject(session), &s); err != nil {
+			t.Fatalf("getting session: %v", err)
+		}
+		if s.Status.FailureReason != factoryv1alpha1.FailureReasonAgentError {
+			t.Errorf("expected failureReason 'AgentError', got %q", s.Status.FailureReason)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

When the agent prompt RPC fails (e.g., invalid API key), the bridge now publishes `session.failed` to NATS instead of silently logging the error. The session moves to `Failed` with `failureReason: AgentError` within seconds instead of hanging in `Active` for up to 1 hour.

Found during live deployment testing on a kind cluster with an invalid API key.

### Before
```
Bridge logs: "failed to send prompt: Invalid API key"
Session phase: Active (hangs until timeout)
User sees: nothing
```

### After
```
Session phase: Failed (within seconds)
Session failureReason: AgentError
User sees: task failed immediately
```

Closes #30

## Test plan

- [x] `TestPromptFailure_PropagatesSessionFailed` — session enters Failed with AgentError when prompt RPC returns error
- [x] All existing tests pass (completion, permission, smoke)
- [x] Lint: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)