### PR TITLE
feat: wire MCP server endpoints from Pool to bridge to SDK

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -60,6 +61,19 @@ func main() {
 
 	// Create session manager.
 	sessionManager := bridge.NewSessionManager(sdkClient, logger)
+
+	// Parse MCP_SERVERS env var (set by the sandbox controller from the Pool's
+	// mcpServers list) and offer those endpoints to every session this bridge
+	// creates.
+	if raw := os.Getenv("MCP_SERVERS"); raw != "" {
+		var servers []bridge.MCPServer
+		if err := json.Unmarshal([]byte(raw), &servers); err != nil {
+			logger.Error("invalid MCP_SERVERS JSON, ignoring", "error", err, "raw", raw)
+		} else {
+			sessionManager.SetMCPServers(servers)
+			logger.Info("loaded MCP servers", "count", len(servers))
+		}
+	}
 
 	// Set up event forwarding if NATS is configured.
 	var eventForwarder *bridge.EventForwarder

--- a/internal/bridge/sdkclient.go
+++ b/internal/bridge/sdkclient.go
@@ -45,9 +45,16 @@ func NewSDKClientWithHTTP(baseURL string, httpClient *http.Client) *SDKClient {
 
 // ACPConfig holds configuration for creating an ACP session.
 type ACPConfig struct {
-	Agent          string `json:"agent"`
-	WorkDir        string `json:"workDir,omitempty"`
-	PermissionMode string `json:"permissionMode,omitempty"`
+	Agent          string      `json:"agent"`
+	WorkDir        string      `json:"workDir,omitempty"`
+	PermissionMode string      `json:"permissionMode,omitempty"`
+	MCPServers     []MCPServer `json:"mcpServers,omitempty"`
+}
+
+// MCPServer is an MCP endpoint passed to the SDK in session/new.
+type MCPServer struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
 // ACPSessionResponse is the response from creating an ACP session.
@@ -180,8 +187,12 @@ func (c *SDKClient) CreateACPSession(ctx context.Context, cfg ACPConfig) (string
 	if cwd == "" {
 		cwd = "/workspace"
 	}
+	mcpServers := cfg.MCPServers
+	if mcpServers == nil {
+		mcpServers = []MCPServer{}
+	}
 	sessionParams := map[string]interface{}{
-		"mcpServers": []interface{}{},
+		"mcpServers": mcpServers,
 		"cwd":        cwd,
 	}
 

--- a/internal/bridge/sdkclient_test.go
+++ b/internal/bridge/sdkclient_test.go
@@ -89,6 +89,90 @@ func TestCreateACPSession(t *testing.T) {
 	}
 }
 
+func TestCreateACPSessionForwardsMCPServers(t *testing.T) {
+	var sessionNewParams map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rpcReq jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&rpcReq); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		switch rpcReq.Method {
+		case "initialize":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpcReq.ID, Result: json.RawMessage(`{"protocolVersion":1}`)})
+		case "session/new":
+			sessionNewParams = rpcReq.Params.(map[string]interface{})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpcReq.ID, Result: json.RawMessage(`{"sessionId":"sess-mcp"}`)})
+		case "session/set_config_option":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpcReq.ID, Result: json.RawMessage(`{}`)})
+		}
+	}))
+	defer server.Close()
+
+	client := NewSDKClientWithHTTP(server.URL, server.Client())
+	_, err := client.CreateACPSession(context.Background(), ACPConfig{
+		Agent: "claude-code",
+		MCPServers: []MCPServer{
+			{Name: "github", URL: "http://github-mcp.svc:8080"},
+			{Name: "postgres", URL: "https://postgres-mcp.example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := sessionNewParams["mcpServers"].([]interface{})
+	if !ok {
+		t.Fatalf("expected mcpServers to be a JSON array, got %T", sessionNewParams["mcpServers"])
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 mcpServers, got %d", len(got))
+	}
+	first := got[0].(map[string]interface{})
+	if first["name"] != "github" || first["url"] != "http://github-mcp.svc:8080" {
+		t.Errorf("first mcpServer = %+v, want {name:github, url:http://github-mcp.svc:8080}", first)
+	}
+}
+
+func TestCreateACPSessionEmptyMCPServers(t *testing.T) {
+	var sessionNewParams map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rpcReq jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&rpcReq); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		switch rpcReq.Method {
+		case "initialize":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpcReq.ID, Result: json.RawMessage(`{"protocolVersion":1}`)})
+		case "session/new":
+			sessionNewParams = rpcReq.Params.(map[string]interface{})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpcReq.ID, Result: json.RawMessage(`{"sessionId":"sess"}`)})
+		case "session/set_config_option":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpcReq.ID, Result: json.RawMessage(`{}`)})
+		}
+	}))
+	defer server.Close()
+
+	client := NewSDKClientWithHTTP(server.URL, server.Client())
+	if _, err := client.CreateACPSession(context.Background(), ACPConfig{Agent: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Nil MCPServers must marshal to [] not null — the SDK rejects null here.
+	got, ok := sessionNewParams["mcpServers"].([]interface{})
+	if !ok {
+		t.Fatalf("expected mcpServers to be a JSON array, got %T (%v)", sessionNewParams["mcpServers"], sessionNewParams["mcpServers"])
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty mcpServers array, got %v", got)
+	}
+}
+
 func TestCreateACPSessionError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/bridge/session.go
+++ b/internal/bridge/session.go
@@ -9,8 +9,9 @@ import (
 
 // SessionManager manages agent sessions via the Sandbox Agent SDK.
 type SessionManager struct {
-	sdk    *SDKClient
-	logger *slog.Logger
+	sdk        *SDKClient
+	logger     *slog.Logger
+	mcpServers []MCPServer
 
 	mu       sync.RWMutex
 	sessions map[string]*sessionState
@@ -29,6 +30,12 @@ func NewSessionManager(sdk *SDKClient, logger *slog.Logger) *SessionManager {
 		logger:   logger,
 		sessions: make(map[string]*sessionState),
 	}
+}
+
+// SetMCPServers configures the MCP server endpoints offered to every session
+// this manager creates. Pool-level config — set once at bridge startup.
+func (m *SessionManager) SetMCPServers(servers []MCPServer) {
+	m.mcpServers = servers
 }
 
 // StartSessionConfig holds parameters for starting a session.
@@ -73,6 +80,7 @@ func (m *SessionManager) StartSession(ctx context.Context, cfg StartSessionConfi
 		Agent:          cfg.AgentType,
 		WorkDir:        cfg.WorkDir,
 		PermissionMode: cfg.PermissionMode,
+		MCPServers:     m.mcpServers,
 	})
 	if err != nil {
 		return "", fmt.Errorf("creating ACP session: %w", err)

--- a/internal/controller/sandbox_controller.go
+++ b/internal/controller/sandbox_controller.go
@@ -2,7 +2,10 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -400,6 +403,26 @@ func (r *SandboxReconciler) ensureNetworkPolicy(ctx context.Context, sandbox *fa
 		}
 	}
 
+	// Allow egress to each MCP server's port. NetworkPolicy can't filter by
+	// hostname, so this matches the existing EgressRules pattern: port-restrict
+	// against 0.0.0.0/0. Operators who need stricter isolation should pin
+	// MCP servers to in-cluster Services and add a tighter EgressRule.
+	for _, srv := range pool.Spec.SandboxTemplate.MCPServers {
+		port := mcpServerPort(srv.URL)
+		if port == 0 {
+			continue
+		}
+		p := intstr.FromInt32(port)
+		egressRules = append(egressRules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Port: &p, Protocol: &protocolTCP},
+			},
+		})
+	}
+
 	policyTypes := []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
 	netpol := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -581,6 +604,15 @@ func (r *SandboxReconciler) buildPod(sandbox *factoryv1alpha1.Sandbox, pool *fac
 		},
 	}
 
+	// Pass the Pool's MCP server endpoints to the bridge as JSON. The bridge
+	// forwards these to the SDK on session/new so the agent can call MCP tools.
+	if mcpJSON := encodeMCPServers(pool.Spec.SandboxTemplate.MCPServers); mcpJSON != "" {
+		bridgeContainer.Env = append(bridgeContainer.Env, corev1.EnvVar{
+			Name:  "MCP_SERVERS",
+			Value: mcpJSON,
+		})
+	}
+
 	// Apply health check from AgentConfig
 	if agentConfig.Spec.Bridge.HealthCheck != nil && agentConfig.Spec.Bridge.HealthCheck.HTTPGet != nil {
 		hc := agentConfig.Spec.Bridge.HealthCheck
@@ -667,6 +699,54 @@ func isPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// encodeMCPServers marshals the Pool's MCP server list into the JSON shape the
+// bridge expects in MCP_SERVERS. Returns "" when there are no entries so the
+// env var is omitted entirely (the bridge treats unset and empty identically).
+func encodeMCPServers(servers []factoryv1alpha1.MCPServerEndpoint) string {
+	if len(servers) == 0 {
+		return ""
+	}
+	type entry struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	}
+	out := make([]entry, len(servers))
+	for i, s := range servers {
+		out[i] = entry{Name: s.Name, URL: s.URL}
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// mcpServerPort returns the TCP port the agent will dial for the given MCP
+// server URL. Defaults to 80 for http, 443 for https when the URL omits a port.
+// Returns 0 if the URL is unparseable or uses an unsupported scheme — admission
+// validation (Pattern=^https?://) keeps this in practice unreachable.
+func mcpServerPort(rawURL string) int32 {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 0
+	}
+	if p := u.Port(); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil || n <= 0 || n > 65535 {
+			return 0
+		}
+		return int32(n)
+	}
+	switch u.Scheme {
+	case "http":
+		return 80
+	case "https":
+		return 443
+	default:
+		return 0
+	}
 }
 
 func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/sandbox_controller_test.go
+++ b/internal/controller/sandbox_controller_test.go
@@ -577,6 +577,108 @@ func TestSandboxReconciler_PodSpec(t *testing.T) {
 	}
 }
 
+func TestSandboxReconciler_MCPServers(t *testing.T) {
+	scheme := newScheme()
+	_ = networkingv1.AddToScheme(scheme)
+
+	pool := newTestPool("test-pool", "default")
+	pool.Spec.SandboxTemplate.MCPServers = []factoryv1alpha1.MCPServerEndpoint{
+		{Name: "github", URL: "http://github-mcp.team-alpha.svc:8080"},
+		{Name: "postgres", URL: "https://postgres-mcp.example.com"},
+	}
+
+	sandbox := newTestSandbox("sb-mcp", "default", "test-pool", "test-agent", "")
+	agentConfig := newAgentConfig("test-agent", "default")
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sandbox, pool, agentConfig).
+		WithStatusSubresource(&factoryv1alpha1.Sandbox{}).
+		Build()
+
+	reconciler := &SandboxReconciler{Client: fc, Scheme: scheme}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "sb-mcp", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	// MCP_SERVERS env var on bridge container, JSON-encoded.
+	var pod corev1.Pod
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "sb-mcp", Namespace: "default"}, &pod); err != nil {
+		t.Fatalf("getting pod: %v", err)
+	}
+	bridgeContainer := pod.Spec.Containers[1]
+	var mcpEnv string
+	for _, e := range bridgeContainer.Env {
+		if e.Name == "MCP_SERVERS" {
+			mcpEnv = e.Value
+		}
+	}
+	if mcpEnv == "" {
+		t.Fatal("expected MCP_SERVERS env var on bridge container")
+	}
+	wantJSON := `[{"name":"github","url":"http://github-mcp.team-alpha.svc:8080"},{"name":"postgres","url":"https://postgres-mcp.example.com"}]`
+	if mcpEnv != wantJSON {
+		t.Errorf("MCP_SERVERS = %q, want %q", mcpEnv, wantJSON)
+	}
+
+	// NetworkPolicy: one egress rule per MCP server, port-restricted.
+	var netpol networkingv1.NetworkPolicy
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "sb-mcp-netpol", Namespace: "default"}, &netpol); err != nil {
+		t.Fatalf("getting network policy: %v", err)
+	}
+	// Expect: 1 baseline (DNS+NATS) + 2 MCP rules.
+	if len(netpol.Spec.Egress) != 3 {
+		t.Fatalf("expected 3 egress rules, got %d", len(netpol.Spec.Egress))
+	}
+	gotPorts := []int32{
+		int32(netpol.Spec.Egress[1].Ports[0].Port.IntValue()),
+		int32(netpol.Spec.Egress[2].Ports[0].Port.IntValue()),
+	}
+	if gotPorts[0] != 8080 {
+		t.Errorf("first MCP egress port = %d, want 8080", gotPorts[0])
+	}
+	if gotPorts[1] != 443 {
+		t.Errorf("second MCP egress port = %d, want 443 (default for https)", gotPorts[1])
+	}
+}
+
+func TestSandboxReconciler_MCPServersEmpty(t *testing.T) {
+	scheme := newScheme()
+	_ = networkingv1.AddToScheme(scheme)
+
+	pool := newTestPool("test-pool", "default")
+	// No MCPServers configured.
+	sandbox := newTestSandbox("sb-no-mcp", "default", "test-pool", "test-agent", "")
+	agentConfig := newAgentConfig("test-agent", "default")
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sandbox, pool, agentConfig).
+		WithStatusSubresource(&factoryv1alpha1.Sandbox{}).
+		Build()
+
+	reconciler := &SandboxReconciler{Client: fc, Scheme: scheme}
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "sb-no-mcp", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var pod corev1.Pod
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "sb-no-mcp", Namespace: "default"}, &pod); err != nil {
+		t.Fatalf("getting pod: %v", err)
+	}
+	for _, e := range pod.Spec.Containers[1].Env {
+		if e.Name == "MCP_SERVERS" {
+			t.Errorf("MCP_SERVERS env var should be omitted when no servers configured, got %q", e.Value)
+		}
+	}
+}
+
 func TestSandboxReconciler_NetworkPolicyWithEgressRules(t *testing.T) {
 	scheme := newScheme()
 	_ = networkingv1.AddToScheme(scheme)


### PR DESCRIPTION
## Summary

Implements the MCP wiring described in spec/06 from #46. The `Pool.spec.sandboxTemplate.mcpServers` list now actually flows through to the agent via the bridge sidecar.

### Pipeline

1. **Sandbox controller** serializes `pool.mcpServers` as JSON into the bridge container's `MCP_SERVERS` env var. Empty list omits the env var entirely.
2. **Sandbox NetworkPolicy** gains a port-restricted egress rule per MCP server URL — port parsed from the URL (defaults to 80 for http, 443 for https when omitted).
3. **Bridge** parses `MCP_SERVERS` at startup and stores endpoints on `SessionManager`.
4. **SessionManager** forwards them through `ACPConfig.MCPServers` to `CreateACPSession`, which puts them in the `session/new` JSON-RPC payload.

### Files

| File | Change |
|---|---|
| `internal/controller/sandbox_controller.go` | `buildPod` adds `MCP_SERVERS` env; `ensureNetworkPolicy` adds egress rules; helpers `encodeMCPServers` and `mcpServerPort` |
| `internal/bridge/sdkclient.go` | `ACPConfig.MCPServers` field + `MCPServer` type; `CreateACPSession` forwards them |
| `internal/bridge/session.go` | `SessionManager.SetMCPServers` (pool-level, set once at startup) |
| `cmd/bridge/main.go` | Parses `MCP_SERVERS` env into `SessionManager` |

### Notes

- Nil `MCPServers` still marshals as `[]` in `session/new` — the SDK rejects `null`.
- NetworkPolicy can't filter by hostname, so each MCP entry adds a port-restricted egress against `0.0.0.0/0` — matches the existing `EgressRules` pattern. Operators wanting stricter isolation should pin to in-cluster Services and add a tighter `EgressRule`.

## Test plan

- [x] New tests: `TestSandboxReconciler_MCPServers`, `TestSandboxReconciler_MCPServersEmpty` (env var injection + egress rules)
- [x] New tests: `TestCreateACPSessionForwardsMCPServers`, `TestCreateACPSessionEmptyMCPServers` (session/new payload)
- [x] `make build` clean
- [x] `make lint` 0 issues (after upgrading local golangci-lint to v2.12.1; pre-existing config/binary mismatch — separate issue)
- [x] `go test -short -race ./...` passes
- [ ] `make test` (full integration via envtest) — blocked by pre-existing `TestIntegration` hang on `main`; investigated separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)