### PR TITLE
fix: agent-runner foundations (auth, egress, retry, error visibility)

### DIFF
--- a/api/v1alpha1/session_types.go
+++ b/api/v1alpha1/session_types.go
@@ -34,7 +34,7 @@ type PendingApproval struct {
 }
 
 // FailureReason indicates why a session entered the Failed phase.
-// +kubebuilder:validation:Enum=AgentError;Timeout;BridgeLost
+// +kubebuilder:validation:Enum=AgentError;Timeout;BridgeLost;AuthError
 type FailureReason string
 
 const (
@@ -46,6 +46,11 @@ const (
 
 	// FailureReasonBridgeLost means the bridge became unreachable.
 	FailureReasonBridgeLost FailureReason = "BridgeLost"
+
+	// FailureReasonAuthError means the agent could not authenticate to its
+	// upstream provider (invalid/expired API key, missing auth method).
+	// Terminal — no point retrying without operator intervention.
+	FailureReasonAuthError FailureReason = "AuthError"
 )
 
 // SessionMode controls whether a session auto-completes after a single prompt
@@ -113,6 +118,17 @@ type SessionStatus struct {
 	// Set only when Phase is Failed.
 	// +optional
 	FailureReason FailureReason `json:"failureReason,omitempty"`
+
+	// FailureMessage is a human-readable description of the failure.
+	// Set only when Phase is Failed.
+	// +optional
+	FailureMessage string `json:"failureMessage,omitempty"`
+
+	// StartAttempts counts how many times the session controller has tried
+	// to start this session on the bridge. Used to bound retries on
+	// transient bridge failures.
+	// +optional
+	StartAttempts int32 `json:"startAttempts,omitempty"`
 
 	// EventStreamSubject is the NATS subject for this session's event stream.
 	// +optional

--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -93,6 +93,16 @@ type TaskStatus struct {
 	// Attempts is the number of attempts made so far.
 	Attempts int32 `json:"attempts"`
 
+	// FailureReason indicates why the task failed, propagated from the
+	// session that ran it. Set only when Phase is Failed.
+	// +optional
+	FailureReason FailureReason `json:"failureReason,omitempty"`
+
+	// FailureMessage is a human-readable description of the failure,
+	// propagated from the session. Set only when Phase is Failed.
+	// +optional
+	FailureMessage string `json:"failureMessage,omitempty"`
+
 	// TokenUsage tracks token consumption for this task.
 	// +optional
 	TokenUsage *TokenUsage `json:"tokenUsage,omitempty"`

--- a/config/crd/bases/factory.example.com_sessions.yaml
+++ b/config/crd/bases/factory.example.com_sessions.yaml
@@ -158,6 +158,11 @@ spec:
                 description: EventStreamSubject is the NATS subject for this session's
                   event stream.
                 type: string
+              failureMessage:
+                description: |-
+                  FailureMessage is a human-readable description of the failure.
+                  Set only when Phase is Failed.
+                type: string
               failureReason:
                 description: |-
                   FailureReason indicates why the session failed.
@@ -166,6 +171,7 @@ spec:
                 - AgentError
                 - Timeout
                 - BridgeLost
+                - AuthError
                 type: string
               pendingApproval:
                 description: |-
@@ -201,6 +207,13 @@ spec:
                 - Failed
                 - Cancelled
                 type: string
+              startAttempts:
+                description: |-
+                  StartAttempts counts how many times the session controller has tried
+                  to start this session on the bridge. Used to bound retries on
+                  transient bridge failures.
+                format: int32
+                type: integer
               startedAt:
                 description: StartedAt is the time the session started.
                 format: date-time

--- a/config/crd/bases/factory.example.com_tasks.yaml
+++ b/config/crd/bases/factory.example.com_tasks.yaml
@@ -172,6 +172,21 @@ spec:
                   - type
                   type: object
                 type: array
+              failureMessage:
+                description: |-
+                  FailureMessage is a human-readable description of the failure,
+                  propagated from the session. Set only when Phase is Failed.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates why the task failed, propagated from the
+                  session that ran it. Set only when Phase is Failed.
+                enum:
+                - AgentError
+                - Timeout
+                - BridgeLost
+                - AuthError
+                type: string
               phase:
                 description: Phase is the current phase of the task.
                 enum:

--- a/internal/apiserver/handlers_test.go
+++ b/internal/apiserver/handlers_test.go
@@ -292,6 +292,40 @@ func TestGetTask(t *testing.T) {
 	}
 }
 
+func TestGetTask_FailureReasonAndMessage(t *testing.T) {
+	task := &factoryv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-task", Namespace: "default"},
+		Spec:       factoryv1alpha1.TaskSpec{PoolRef: factoryv1alpha1.LocalObjectReference{Name: "pool1"}, Prompt: "x"},
+		Status: factoryv1alpha1.TaskStatus{
+			Phase:          factoryv1alpha1.TaskPhaseFailed,
+			FailureReason:  factoryv1alpha1.FailureReasonAuthError,
+			FailureMessage: "ACP session/new: Authentication required",
+		},
+	}
+	_, mux := testHandlers(task)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/tasks/failed-task", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp TaskResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if resp.Phase != "Failed" {
+		t.Errorf("phase = %q, want Failed", resp.Phase)
+	}
+	if resp.FailureReason != "AuthError" {
+		t.Errorf("failureReason = %q, want AuthError", resp.FailureReason)
+	}
+	if resp.FailureMessage == "" {
+		t.Error("failureMessage should be present on failed task")
+	}
+}
+
 func TestGetTask_NotFound(t *testing.T) {
 	_, mux := testHandlers()
 

--- a/internal/apiserver/types.go
+++ b/internal/apiserver/types.go
@@ -41,17 +41,19 @@ type CreateTaskRequest struct {
 
 // TaskResponse is the response for task endpoints.
 type TaskResponse struct {
-	ID          string                       `json:"id"`
-	Name        string                       `json:"name"`
-	Namespace   string                       `json:"namespace"`
-	Phase       string                       `json:"phase"`
-	SandboxRef  string                       `json:"sandboxRef,omitempty"`
-	SessionRef  string                       `json:"sessionRef,omitempty"`
-	Attempts    int32                        `json:"attempts"`
-	StartedAt   *time.Time                   `json:"startedAt,omitempty"`
-	CompletedAt *time.Time                   `json:"completedAt,omitempty"`
-	TokenUsage  *factoryv1alpha1.TokenUsage  `json:"tokenUsage,omitempty"`
-	CreatedAt   time.Time                    `json:"createdAt"`
+	ID             string                      `json:"id"`
+	Name           string                      `json:"name"`
+	Namespace      string                      `json:"namespace"`
+	Phase          string                      `json:"phase"`
+	SandboxRef     string                      `json:"sandboxRef,omitempty"`
+	SessionRef     string                      `json:"sessionRef,omitempty"`
+	Attempts       int32                       `json:"attempts"`
+	FailureReason  string                      `json:"failureReason,omitempty"`
+	FailureMessage string                      `json:"failureMessage,omitempty"`
+	StartedAt      *time.Time                  `json:"startedAt,omitempty"`
+	CompletedAt    *time.Time                  `json:"completedAt,omitempty"`
+	TokenUsage     *factoryv1alpha1.TokenUsage `json:"tokenUsage,omitempty"`
+	CreatedAt      time.Time                   `json:"createdAt"`
 }
 
 // PoolResponse is the response for pool endpoints.
@@ -138,13 +140,15 @@ func workflowFromCR(w *factoryv1alpha1.Workflow) WorkflowResponse {
 // taskFromCR converts a Task CR to a TaskResponse.
 func taskFromCR(t *factoryv1alpha1.Task) TaskResponse {
 	resp := TaskResponse{
-		ID:         string(t.UID),
-		Name:       t.Name,
-		Namespace:  t.Namespace,
-		Phase:      string(t.Status.Phase),
-		Attempts:   t.Status.Attempts,
-		TokenUsage: t.Status.TokenUsage,
-		CreatedAt:  t.CreationTimestamp.Time,
+		ID:             string(t.UID),
+		Name:           t.Name,
+		Namespace:      t.Namespace,
+		Phase:          string(t.Status.Phase),
+		Attempts:       t.Status.Attempts,
+		FailureReason:  string(t.Status.FailureReason),
+		FailureMessage: t.Status.FailureMessage,
+		TokenUsage:     t.Status.TokenUsage,
+		CreatedAt:      t.CreationTimestamp.Time,
 	}
 	if t.Status.SandboxRef != nil {
 		resp.SandboxRef = t.Status.SandboxRef.Name

--- a/internal/bridge/sdkclient.go
+++ b/internal/bridge/sdkclient.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -180,7 +181,20 @@ func (c *SDKClient) CreateACPSession(ctx context.Context, cfg ACPConfig) (string
 	if err != nil {
 		return "", fmt.Errorf("ACP initialize: %w", err)
 	}
-	_ = initResp
+
+	// Step 1b: If the agent declared auth methods (Codex etc.), pick one and
+	// run `authenticate` before session/new. Claude returns an empty list and
+	// auto-auths from ANTHROPIC_API_KEY; this branch is a no-op for it.
+	if methodID := chooseAuthMethod(initResp.Result); methodID != "" {
+		if _, err := c.sendRPC(ctx, acpURL, jsonRPCRequest{
+			JSONRPC: "2.0",
+			ID:      c.nextID.Add(1),
+			Method:  "authenticate",
+			Params:  map[string]interface{}{"methodId": methodID},
+		}); err != nil {
+			return "", fmt.Errorf("ACP authenticate (methodId=%s): %w", methodID, err)
+		}
+	}
 
 	// Step 2: Create a new session.
 	cwd := cfg.WorkDir
@@ -256,6 +270,47 @@ func (c *SDKClient) getSessionID(serverID string) string {
 	sessionIDMap.RLock()
 	defer sessionIDMap.RUnlock()
 	return sessionIDMap.m[serverID]
+}
+
+// chooseAuthMethod inspects the result of `initialize` and returns the methodId
+// to pass to `authenticate`, or "" if the agent doesn't require it. Prefers
+// env-var methods whose required env vars are set in this process; falls back
+// to the first env-var method so the resulting authenticate error is clearer
+// than a downstream "Authentication required" from session/new.
+func chooseAuthMethod(initResult json.RawMessage) string {
+	var r struct {
+		AuthMethods []struct {
+			ID   string `json:"id"`
+			Type string `json:"type"`
+			Vars []struct {
+				Name string `json:"name"`
+			} `json:"vars"`
+		} `json:"authMethods"`
+	}
+	if err := json.Unmarshal(initResult, &r); err != nil || len(r.AuthMethods) == 0 {
+		return ""
+	}
+	for _, m := range r.AuthMethods {
+		if m.Type != "env_var" || len(m.Vars) == 0 {
+			continue
+		}
+		allSet := true
+		for _, v := range m.Vars {
+			if os.Getenv(v.Name) == "" {
+				allSet = false
+				break
+			}
+		}
+		if allSet {
+			return m.ID
+		}
+	}
+	for _, m := range r.AuthMethods {
+		if m.Type == "env_var" {
+			return m.ID
+		}
+	}
+	return ""
 }
 
 // SendACPMessage sends a prompt to an active ACP session using the session/prompt method.

--- a/internal/bridge/sdkclient_test.go
+++ b/internal/bridge/sdkclient_test.go
@@ -89,6 +89,125 @@ func TestCreateACPSession(t *testing.T) {
 	}
 }
 
+func TestCreateACPSession_Authenticate(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+
+	var sawAuthenticate bool
+	var authParams map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rpc jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&rpc); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		switch rpc.Method {
+		case "initialize":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{
+				JSONRPC: "2.0", ID: rpc.ID,
+				Result: json.RawMessage(`{
+					"protocolVersion": 1,
+					"authMethods": [
+						{"id":"chatgpt","name":"Login with ChatGPT"},
+						{"id":"openai-api-key","type":"env_var","vars":[{"name":"OPENAI_API_KEY"}]}
+					]
+				}`),
+			})
+		case "authenticate":
+			sawAuthenticate = true
+			authParams = rpc.Params.(map[string]interface{})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{}`)})
+		case "session/new":
+			if !sawAuthenticate {
+				t.Errorf("session/new called before authenticate")
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{"sessionId":"s"}`)})
+		case "session/set_config_option":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{}`)})
+		}
+	}))
+	defer server.Close()
+
+	c := NewSDKClientWithHTTP(server.URL, server.Client())
+	if _, err := c.CreateACPSession(context.Background(), ACPConfig{Agent: "codex"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawAuthenticate {
+		t.Fatal("expected authenticate to be called")
+	}
+	if got := authParams["methodId"]; got != "openai-api-key" {
+		t.Errorf("methodId = %v, want openai-api-key", got)
+	}
+}
+
+func TestCreateACPSession_NoAuthMethods(t *testing.T) {
+	// Claude: empty authMethods list — should NOT call authenticate.
+	var sawAuthenticate bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rpc jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&rpc); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		switch rpc.Method {
+		case "initialize":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{"protocolVersion":1,"authMethods":[]}`)})
+		case "authenticate":
+			sawAuthenticate = true
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{}`)})
+		case "session/new":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{"sessionId":"s"}`)})
+		case "session/set_config_option":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{JSONRPC: "2.0", ID: rpc.ID, Result: json.RawMessage(`{}`)})
+		}
+	}))
+	defer server.Close()
+
+	c := NewSDKClientWithHTTP(server.URL, server.Client())
+	if _, err := c.CreateACPSession(context.Background(), ACPConfig{Agent: "claude"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawAuthenticate {
+		t.Error("authenticate must not be called when authMethods is empty")
+	}
+}
+
+func TestChooseAuthMethod(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	t.Setenv("CODEX_API_KEY", "")
+
+	tests := []struct {
+		name string
+		init string
+		want string
+	}{
+		{"empty list", `{"authMethods":[]}`, ""},
+		{"only chatgpt", `{"authMethods":[{"id":"chatgpt","name":"Login"}]}`, ""},
+		{"prefer env var with set value", `{"authMethods":[
+			{"id":"codex-api-key","type":"env_var","vars":[{"name":"CODEX_API_KEY"}]},
+			{"id":"openai-api-key","type":"env_var","vars":[{"name":"OPENAI_API_KEY"}]}
+		]}`, "openai-api-key"},
+		{"fall back to first env_var when none set", `{"authMethods":[
+			{"id":"chatgpt"},
+			{"id":"codex-api-key","type":"env_var","vars":[{"name":"CODEX_API_KEY"}]}
+		]}`, "codex-api-key"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chooseAuthMethod(json.RawMessage(tc.init))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCreateACPSessionForwardsMCPServers(t *testing.T) {
 	var sessionNewParams map[string]interface{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/controller/sandbox_controller.go
+++ b/internal/controller/sandbox_controller.go
@@ -103,7 +103,7 @@ func (r *SandboxReconciler) reconcileCreating(ctx context.Context, sandbox *fact
 	}
 
 	// Create NetworkPolicy if it doesn't exist
-	if err := r.ensureNetworkPolicy(ctx, sandbox, pool); err != nil {
+	if err := r.ensureNetworkPolicy(ctx, sandbox, pool, agentConfig); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring network policy: %w", err)
 	}
 
@@ -348,7 +348,7 @@ func (r *SandboxReconciler) ensureWorkspacePVC(ctx context.Context, sandbox *fac
 	return nil
 }
 
-func (r *SandboxReconciler) ensureNetworkPolicy(ctx context.Context, sandbox *factoryv1alpha1.Sandbox, pool *factoryv1alpha1.Pool) error {
+func (r *SandboxReconciler) ensureNetworkPolicy(ctx context.Context, sandbox *factoryv1alpha1.Sandbox, pool *factoryv1alpha1.Pool, agentConfig *factoryv1alpha1.AgentConfig) error {
 	netpolName := sandbox.Name + "-netpol"
 
 	var existing networkingv1.NetworkPolicy
@@ -421,6 +421,30 @@ func (r *SandboxReconciler) ensureNetworkPolicy(ctx context.Context, sandbox *fa
 				{Port: &p, Protocol: &protocolTCP},
 			},
 		})
+	}
+
+	// Allow HTTPS egress to each AgentConfig credential host. Without this,
+	// a Pool whose AgentConfig declares e.g. host=api.openai.com but whose
+	// Pool spec doesn't list a matching EgressRule would silently fail —
+	// the agent can't reach its own API. Hostname filtering isn't supported
+	// in NetworkPolicy, so this is port-restricted (443) against 0.0.0.0/0.
+	if agentConfig != nil {
+		seen := map[string]bool{}
+		for _, cred := range agentConfig.Spec.Credentials {
+			if cred.Host == nil || *cred.Host == "" || seen[*cred.Host] {
+				continue
+			}
+			seen[*cred.Host] = true
+			httpsPort := intstr.FromInt32(443)
+			egressRules = append(egressRules, networkingv1.NetworkPolicyEgressRule{
+				To: []networkingv1.NetworkPolicyPeer{
+					{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &httpsPort, Protocol: &protocolTCP},
+				},
+			})
+		}
 	}
 
 	policyTypes := []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}

--- a/internal/controller/sandbox_controller_test.go
+++ b/internal/controller/sandbox_controller_test.go
@@ -679,6 +679,51 @@ func TestSandboxReconciler_MCPServersEmpty(t *testing.T) {
 	}
 }
 
+func TestSandboxReconciler_NetworkPolicyFromCredentialHost(t *testing.T) {
+	scheme := newScheme()
+	_ = networkingv1.AddToScheme(scheme)
+
+	pool := newTestPool("test-pool", "default")
+	host1, host2 := "api.openai.com", "api.openai.com" // same host, dedup expected
+	host3 := "api.example.com"
+	agentConfig := newAgentConfig("test-agent", "default")
+	agentConfig.Spec.Credentials = []factoryv1alpha1.CredentialConfig{
+		{Name: "OPENAI_API_KEY", Host: &host1, SecretRef: factoryv1alpha1.SecretKeyReference{Name: "creds", Key: "k"}},
+		{Name: "OPENAI_ORG_ID", Host: &host2, SecretRef: factoryv1alpha1.SecretKeyReference{Name: "creds", Key: "org"}},
+		{Name: "EXAMPLE_TOKEN", Host: &host3, SecretRef: factoryv1alpha1.SecretKeyReference{Name: "creds", Key: "tok"}},
+	}
+
+	sandbox := newTestSandbox("sb-creds", "default", "test-pool", "test-agent", "")
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sandbox, pool, agentConfig).
+		WithStatusSubresource(&factoryv1alpha1.Sandbox{}).
+		Build()
+
+	r := &SandboxReconciler{Client: fc, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "sb-creds", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var netpol networkingv1.NetworkPolicy
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "sb-creds-netpol", Namespace: "default"}, &netpol); err != nil {
+		t.Fatalf("getting netpol: %v", err)
+	}
+
+	// Baseline (DNS+NATS) + 2 deduped credential hosts = 3.
+	if got := len(netpol.Spec.Egress); got != 3 {
+		t.Fatalf("expected 3 egress rules, got %d", got)
+	}
+	for _, rule := range netpol.Spec.Egress[1:] {
+		if len(rule.Ports) != 1 || rule.Ports[0].Port.IntValue() != 443 {
+			t.Errorf("expected credential egress rule on port 443, got %+v", rule.Ports)
+		}
+	}
+}
+
 func TestSandboxReconciler_NetworkPolicyWithEgressRules(t *testing.T) {
 	scheme := newScheme()
 	_ = networkingv1.AddToScheme(scheme)

--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -372,7 +372,15 @@ func (r *SessionReconciler) handleSessionFailed(namespace, sessionName string, e
 	now := metav1.Now()
 	session.Status.Phase = factoryv1alpha1.SessionPhaseFailed
 	session.Status.CompletedAt = &now
-	session.Status.FailureReason = factoryv1alpha1.FailureReasonAgentError
+	// Async failures (model API rejection during prompt) come in as AgentError;
+	// reclassify when the message looks like an auth issue so the API surfaces
+	// the more useful AuthError reason.
+	if isAuthError(data.Reason) {
+		session.Status.FailureReason = factoryv1alpha1.FailureReasonAuthError
+	} else {
+		session.Status.FailureReason = factoryv1alpha1.FailureReasonAgentError
+	}
+	session.Status.FailureMessage = data.Reason
 	_ = r.Status().Update(ctx, &session)
 }
 

--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,6 +24,16 @@ import (
 const (
 	sessionHealthCheckInterval = 15 * time.Second
 	bridgePort                 = 8080
+
+	// maxStartAttempts caps how long the session controller keeps retrying
+	// bridge.StartSession before giving up with phase=Failed. With the
+	// exponential backoff schedule (10s, 20s, 40s, 80s, 160s, 300s capped)
+	// this is roughly 10 minutes of retries for transient failures.
+	maxStartAttempts = 6
+
+	// maxStartBackoff caps the per-retry RequeueAfter so a stuck session
+	// still gets reconciled occasionally.
+	maxStartBackoff = 5 * time.Minute
 )
 
 // BridgeClientFactory creates bridge clients for a given base URL.
@@ -131,7 +142,7 @@ func (r *SessionReconciler) reconcilePending(ctx context.Context, session *facto
 	bridgeSessionID, err := bridgeClient.StartSession(ctx, cfg)
 	if err != nil {
 		logger.Error(err, "failed to start session on bridge")
-		return ctrl.Result{RequeueAfter: defaultRequeueDelay}, nil
+		return r.handleStartSessionError(ctx, session, err)
 	}
 
 	// Update session status to Active.
@@ -155,6 +166,74 @@ func (r *SessionReconciler) reconcilePending(ctx context.Context, session *facto
 	}
 
 	return ctrl.Result{RequeueAfter: sessionHealthCheckInterval}, nil
+}
+
+// handleStartSessionError classifies a bridge.StartSession error and decides
+// whether to retry, back off, or fail the session terminally.
+//
+// Auth-shaped errors (invalid API key, missing auth method) are terminal —
+// retrying with the same credentials won't change anything. Everything else
+// is treated as transient and gets exponential backoff up to maxStartAttempts.
+func (r *SessionReconciler) handleStartSessionError(ctx context.Context, session *factoryv1alpha1.Session, startErr error) (ctrl.Result, error) {
+	msg := startErr.Error()
+
+	if isAuthError(msg) {
+		now := metav1.Now()
+		session.Status.Phase = factoryv1alpha1.SessionPhaseFailed
+		session.Status.FailureReason = factoryv1alpha1.FailureReasonAuthError
+		session.Status.FailureMessage = msg
+		session.Status.CompletedAt = &now
+		if err := r.Status().Update(ctx, session); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating session to Failed (auth): %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	session.Status.StartAttempts++
+	if session.Status.StartAttempts >= maxStartAttempts {
+		now := metav1.Now()
+		session.Status.Phase = factoryv1alpha1.SessionPhaseFailed
+		session.Status.FailureReason = factoryv1alpha1.FailureReasonAgentError
+		session.Status.FailureMessage = fmt.Sprintf("bridge.StartSession failed %d times: %s", session.Status.StartAttempts, msg)
+		session.Status.CompletedAt = &now
+		if err := r.Status().Update(ctx, session); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating session to Failed (max attempts): %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Status().Update(ctx, session); err != nil {
+		return ctrl.Result{}, fmt.Errorf("incrementing startAttempts: %w", err)
+	}
+
+	// Exponential backoff: 10s, 20s, 40s, 80s, 160s, 300s.
+	backoff := time.Duration(1<<session.Status.StartAttempts) * 10 * time.Second
+	if backoff > maxStartBackoff {
+		backoff = maxStartBackoff
+	}
+	return ctrl.Result{RequeueAfter: backoff}, nil
+}
+
+// isAuthError returns true for bridge errors that indicate the agent could
+// not authenticate to its provider — retrying with the same credentials is
+// pointless. Matches the wire messages we've actually seen from Codex,
+// Claude, and the bridge's own ACP layer.
+func isAuthError(msg string) bool {
+	patterns := []string{
+		"Authentication required",   // codex initial session/new without authenticate
+		"Invalid API key",           // claude / generic anthropic
+		"invalid_api_key",           // openai variant
+		"Incorrect API key",         // openai
+		"401 Unauthorized",
+		"403 Forbidden",
+		"ACP authenticate",          // our own bridge wrapping of authenticate failures
+	}
+	for _, p := range patterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // getPermissionMode looks up the AgentConfig for the session's agent type

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -442,5 +443,115 @@ func TestSessionReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestIsAuthError(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"creating ACP session: ACP session/new: JSON-RPC error -32000: Authentication required", true},
+		{"ACP session/prompt: JSON-RPC error -32603: Internal error: Invalid API key · Fix external API key", true},
+		{"openai: invalid_api_key: Incorrect API key provided", true},
+		{"401 Unauthorized", true},
+		{"ACP authenticate (methodId=openai-api-key): JSON-RPC error -32000: bad creds", true},
+		{"i/o timeout", false},
+		{"connection refused", false},
+		{"some other transient error", false},
+	}
+	for _, tc := range cases {
+		got := isAuthError(tc.msg)
+		if got != tc.want {
+			t.Errorf("isAuthError(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+}
+
+func TestHandleStartSessionError_AuthIsTerminal(t *testing.T) {
+	session := &factoryv1alpha1.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec:       factoryv1alpha1.SessionSpec{AgentType: "codex"},
+		Status:     factoryv1alpha1.SessionStatus{Phase: factoryv1alpha1.SessionPhasePending},
+	}
+	r := newSessionReconciler([]client.Object{session}, &fakeBridgeClient{}, nil)
+
+	// Re-fetch so we mutate the persisted version.
+	var s factoryv1alpha1.Session
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "s", Namespace: "default"}, &s)
+
+	res, err := r.handleStartSessionError(context.Background(), &s, fmt.Errorf("ACP session/new: JSON-RPC error -32000: Authentication required"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue on auth error, got %v", res.RequeueAfter)
+	}
+
+	var updated factoryv1alpha1.Session
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "s", Namespace: "default"}, &updated)
+	if updated.Status.Phase != factoryv1alpha1.SessionPhaseFailed {
+		t.Errorf("phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.FailureReason != factoryv1alpha1.FailureReasonAuthError {
+		t.Errorf("failureReason = %q, want AuthError", updated.Status.FailureReason)
+	}
+	if updated.Status.FailureMessage == "" {
+		t.Error("failureMessage should be populated")
+	}
+}
+
+func TestHandleStartSessionError_TransientBacksOff(t *testing.T) {
+	session := &factoryv1alpha1.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "s2", Namespace: "default"},
+		Spec:       factoryv1alpha1.SessionSpec{AgentType: "claude"},
+		Status:     factoryv1alpha1.SessionStatus{Phase: factoryv1alpha1.SessionPhasePending, StartAttempts: 2},
+	}
+	r := newSessionReconciler([]client.Object{session}, &fakeBridgeClient{}, nil)
+
+	var s factoryv1alpha1.Session
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "s2", Namespace: "default"}, &s)
+
+	res, err := r.handleStartSessionError(context.Background(), &s, fmt.Errorf("connection refused"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 1 << 3 * 10s = 80s after this attempt.
+	if res.RequeueAfter < 60*time.Second || res.RequeueAfter > 100*time.Second {
+		t.Errorf("expected ~80s backoff, got %v", res.RequeueAfter)
+	}
+
+	var updated factoryv1alpha1.Session
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "s2", Namespace: "default"}, &updated)
+	if updated.Status.Phase == factoryv1alpha1.SessionPhaseFailed {
+		t.Error("transient error should not transition to Failed yet")
+	}
+	if updated.Status.StartAttempts != 3 {
+		t.Errorf("startAttempts = %d, want 3", updated.Status.StartAttempts)
+	}
+}
+
+func TestHandleStartSessionError_ExceedsMaxAttempts(t *testing.T) {
+	session := &factoryv1alpha1.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "s3", Namespace: "default"},
+		Spec:       factoryv1alpha1.SessionSpec{AgentType: "claude"},
+		Status:     factoryv1alpha1.SessionStatus{Phase: factoryv1alpha1.SessionPhasePending, StartAttempts: maxStartAttempts - 1},
+	}
+	r := newSessionReconciler([]client.Object{session}, &fakeBridgeClient{}, nil)
+
+	var s factoryv1alpha1.Session
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "s3", Namespace: "default"}, &s)
+
+	if _, err := r.handleStartSessionError(context.Background(), &s, fmt.Errorf("connection refused")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated factoryv1alpha1.Session
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "s3", Namespace: "default"}, &updated)
+	if updated.Status.Phase != factoryv1alpha1.SessionPhaseFailed {
+		t.Errorf("phase = %q, want Failed after max attempts", updated.Status.Phase)
+	}
+	if updated.Status.FailureReason != factoryv1alpha1.FailureReasonAgentError {
+		t.Errorf("failureReason = %q, want AgentError", updated.Status.FailureReason)
 	}
 }

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -261,10 +261,19 @@ func (r *TaskReconciler) handleSessionResult(ctx context.Context, task *factoryv
 			return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 		}
 
-		// Exceeded retries, fail the task.
+		// Exceeded retries, fail the task. Propagate the session's failure
+		// reason and message so the user-facing API can show *why* without
+		// requiring a separate Session lookup.
 		now := metav1.Now()
 		task.Status.Phase = factoryv1alpha1.TaskPhaseFailed
 		task.Status.CompletedAt = &now
+		if task.Status.SessionRef != nil {
+			var s factoryv1alpha1.Session
+			if err := r.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: task.Status.SessionRef.Name}, &s); err == nil {
+				task.Status.FailureReason = s.Status.FailureReason
+				task.Status.FailureMessage = s.Status.FailureMessage
+			}
+		}
 		if err := r.Status().Update(ctx, task); err != nil {
 			return ctrl.Result{}, fmt.Errorf("updating task to Failed: %w", err)
 		}
@@ -307,6 +316,8 @@ func (r *TaskReconciler) handleTimeout(ctx context.Context, task *factoryv1alpha
 
 	now := metav1.Now()
 	task.Status.Phase = factoryv1alpha1.TaskPhaseFailed
+	task.Status.FailureReason = factoryv1alpha1.FailureReasonTimeout
+	task.Status.FailureMessage = "task exceeded its spec.timeout"
 	task.Status.CompletedAt = &now
 	if err := r.Status().Update(ctx, task); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating task to Failed on timeout: %w", err)


### PR DESCRIPTION
## Summary

The four small platform issues surfaced when I ran a real personal-assistant prompt and added an OpenAI agent. Each was failing silently or noisily in a way that made the system look broken to a user.

| # | Title | Effect |
|---|---|---|
| 1 | ACP `authenticate` handshake | non-Claude agents (Codex etc.) actually start |
| 2 | NetworkPolicy egress from credentials.host | new AgentConfigs reach their own API by default |
| 3 | Auth errors are terminal, transients back off | failed prompts surface fast; no retry storms |
| 4 | Task API surfaces failureReason / failureMessage | users see *why* a task failed without `kubectl` |

Each is a focused commit on this branch.

## Commits

### `9a96623` fix(bridge): perform ACP authenticate handshake when agent declares it

`CreateACPSession` only did `initialize → session/new`. Codex's initialize response lists `authMethods` and `session/new` returns `Authentication required` until you call `authenticate` first. Now the bridge parses the methods, picks the first env-var method whose required env vars are set (falling back to the first env-var method so the resulting `authenticate` error is clearer than a downstream `session/new` failure), and calls it. Claude's empty `authMethods` is a no-op — its path is unchanged. Three new tests cover the branches.

### `977051a` fix(sandbox): derive NetworkPolicy egress from AgentConfig credentials

Each `AgentConfig.credentials[]` entry has a `host` field that was metadata-only. A Pool whose AgentConfig pointed at e.g. `api.openai.com` but whose Pool spec didn't list a matching `EgressRule` came up Ready and silently couldn't reach its own API — every prompt timed out. The sandbox controller now appends a port-restricted (TCP/443) egress rule per unique `credentials[].host`. Same `0.0.0.0/0` compromise the existing rules make (NetworkPolicy can't filter by hostname). Test covers dedup and the port restriction.

### `2bf17ec` fix(session-controller): classify auth errors as terminal, back off transients

Previously any `bridge.StartSession` failure caused a fixed 10s requeue forever. Bad API key → unbounded retry storm with the Task stuck in `Running` and no surfaced reason. Now `reconcilePending` hands the error to `handleStartSessionError`:

- Auth-shaped errors (`Authentication required` / `Invalid API key` / `401` / `403` / our own `ACP authenticate` wrapper) ⇒ mark Session Failed with new `FailureReasonAuthError`. Same credentials won't help.
- Transient errors ⇒ exponential backoff (10s → 300s capped), giving up after 6 attempts with `FailureReasonAgentError`.

Adds two SessionStatus fields: `StartAttempts` (bounds retries, observable via `kubectl`) and `FailureMessage` (the actual error text). CRD regenerated; tests cover all three branches.

### `a83a1bf` fix(task,api): surface failure reason and message on Task API responses

`TaskStatus` gains `failureReason` and `failureMessage`, populated from the underlying Session when the task transitions to Failed. `handleSessionResult` reads them from the Session before saving; `handleTimeout` sets `Timeout` with a clear message. `TaskResponse` exposes both, so `GET /v1/tasks/X` now returns:

```json
{"phase": "Failed", "failureReason": "AuthError",
 "failureMessage": "ACP session/new: Authentication required"}
```

instead of just `{"phase": "Failed"}`.

## Test plan

- [x] `make build` — clean
- [x] `make lint` — 0 issues
- [x] `make test` (full `go test -p 1 ./... -race` including envtest+testharness) — all green
- [x] New unit tests cover: auth method selection (3 cases), authenticate-not-called when authMethods empty, NetworkPolicy egress dedup, auth-as-terminal classification, transient backoff schedule, max-attempts cutoff, Task API surfacing failureReason/Message
- [ ] Live cluster: codex agent end-to-end via the standard Task path (deferred to a follow-up; this branch is the prerequisite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)