### PR TITLE
chore: bump Dockerfile golang base to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
go.mod was bumped to 1.26.0 in #49 but the Dockerfile still pinned golang:1.25, leaving Docker builds dependent on Go's toolchain auto-download. Pin explicitly.