### PR TITLE
fix(task-controller): claim Idle sandboxes (realize the warm-pool intent)

### DIFF
--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -121,11 +121,15 @@ func (r *TaskReconciler) reconcileRunning(ctx context.Context, task *factoryv1al
 	}
 }
 
-// claimSandbox finds a Ready sandbox and atomically claims it. Retries up to
-// 3 times on conflict (the sandbox controller may update the sandbox concurrently).
+// claimSandbox finds an available sandbox and atomically claims it. Retries up
+// to 3 times on conflict (the sandbox controller may update the sandbox
+// concurrently). An "available" sandbox is one in Ready phase OR Idle phase
+// (released by a previous task, still warm) — claiming an Idle sandbox is
+// what realises the Pool's warm-pool intent: the next task gets sub-second
+// startup instead of waiting for sandbox creation.
 func (r *TaskReconciler) claimSandbox(ctx context.Context, task *factoryv1alpha1.Task) (*factoryv1alpha1.Sandbox, error) {
 	for attempt := 0; attempt < 3; attempt++ {
-		sandbox, err := r.findReadySandbox(ctx, task)
+		sandbox, err := r.findAvailableSandbox(ctx, task)
 		if err != nil {
 			return nil, err
 		}
@@ -133,8 +137,12 @@ func (r *TaskReconciler) claimSandbox(ctx context.Context, task *factoryv1alpha1
 			return nil, nil
 		}
 
+		now := metav1.Now()
 		sandbox.Status.Phase = factoryv1alpha1.SandboxPhaseAssigned
 		sandbox.Status.AssignedTask = task.Name
+		// Refresh activity timestamp so the sandbox controller's idle-aging
+		// logic doesn't fire mid-task on a sandbox we just claimed out of Idle.
+		sandbox.Status.LastActivityAt = &now
 		if err := r.Status().Update(ctx, sandbox); err != nil {
 			if errors.IsConflict(err) {
 				continue // Retry with a fresh sandbox lookup
@@ -143,7 +151,6 @@ func (r *TaskReconciler) claimSandbox(ctx context.Context, task *factoryv1alpha1
 		}
 
 		// Update task status with sandbox ref.
-		now := metav1.Now()
 		task.Status.Phase = factoryv1alpha1.TaskPhaseRunning
 		task.Status.SandboxRef = &factoryv1alpha1.LocalObjectReference{Name: sandbox.Name}
 		task.Status.StartedAt = &now
@@ -159,20 +166,38 @@ func (r *TaskReconciler) claimSandbox(ctx context.Context, task *factoryv1alpha1
 	return nil, nil
 }
 
-func (r *TaskReconciler) findReadySandbox(ctx context.Context, task *factoryv1alpha1.Task) (*factoryv1alpha1.Sandbox, error) {
+// findAvailableSandbox returns a sandbox in this Pool that's either Ready or
+// Idle. Idle sandboxes are warm (released by a previous task) and claiming
+// one avoids the sandbox-creation cost. Without this, an Idle sandbox blocks
+// the Pool from creating a replacement (it counts toward min replicas) while
+// also being unclaimable — tasks would queue until the idle timeout fires.
+func (r *TaskReconciler) findAvailableSandbox(ctx context.Context, task *factoryv1alpha1.Task) (*factoryv1alpha1.Sandbox, error) {
 	var sandboxList factoryv1alpha1.SandboxList
 	if err := r.List(ctx, &sandboxList, client.InNamespace(task.Namespace)); err != nil {
 		return nil, fmt.Errorf("listing sandboxes: %w", err)
 	}
 
+	// Prefer Ready over Idle to keep warmer sandboxes around for short-burst
+	// workloads, but fall back to Idle when no Ready sandbox is available.
+	var idle *factoryv1alpha1.Sandbox
 	for i := range sandboxList.Items {
 		sb := &sandboxList.Items[i]
-		if sb.Spec.PoolRef.Name == task.Spec.PoolRef.Name && sb.Status.Phase == factoryv1alpha1.SandboxPhaseReady {
+		if sb.Spec.PoolRef.Name != task.Spec.PoolRef.Name {
+			continue
+		}
+		switch sb.Status.Phase {
+		case factoryv1alpha1.SandboxPhaseReady:
 			return sb, nil
+		case factoryv1alpha1.SandboxPhaseIdle:
+			if idle == nil {
+				idle = sb
+			}
+		case factoryv1alpha1.SandboxPhaseCreating, factoryv1alpha1.SandboxPhaseAssigned,
+			factoryv1alpha1.SandboxPhaseActive, factoryv1alpha1.SandboxPhaseTerminating:
+			// Not claimable — already busy or going away.
 		}
 	}
-
-	return nil, nil
+	return idle, nil
 }
 
 func (r *TaskReconciler) ensureSession(ctx context.Context, task *factoryv1alpha1.Task) (ctrl.Result, error) {

--- a/internal/controller/task_controller_test.go
+++ b/internal/controller/task_controller_test.go
@@ -124,6 +124,111 @@ func TestTaskReconciler_PendingClaimsSandbox(t *testing.T) {
 	}
 }
 
+// TestTaskReconciler_PendingClaimsIdleSandbox asserts the warm-pool intent:
+// when no Ready sandbox is available but an Idle one exists (released by a
+// previous task), a new task can claim it instead of waiting for the idle
+// timeout to fire and the Pool to spin up a fresh sandbox.
+func TestTaskReconciler_PendingClaimsIdleSandbox(t *testing.T) {
+	scheme := newScheme()
+	task := newTask("test-task", "default", "test-pool")
+
+	twoMinAgo := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	sb := &factoryv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-idle", Namespace: "default"},
+		Spec: factoryv1alpha1.SandboxSpec{
+			PoolRef:        factoryv1alpha1.LocalObjectReference{Name: "test-pool"},
+			AgentConfigRef: factoryv1alpha1.LocalObjectReference{Name: "agent"},
+		},
+		Status: factoryv1alpha1.SandboxStatus{
+			Phase:          factoryv1alpha1.SandboxPhaseIdle,
+			LastActivityAt: &twoMinAgo,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(task, sb).
+		WithStatusSubresource(&factoryv1alpha1.Task{}, &factoryv1alpha1.Sandbox{}, &factoryv1alpha1.Session{}).
+		Build()
+
+	r := &TaskReconciler{Client: fakeClient, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-task", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated factoryv1alpha1.Sandbox
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "sb-idle", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("fetching sandbox: %v", err)
+	}
+	if updated.Status.Phase != factoryv1alpha1.SandboxPhaseAssigned {
+		t.Errorf("Idle sandbox should have been claimed; phase = %s", updated.Status.Phase)
+	}
+	if updated.Status.AssignedTask != "test-task" {
+		t.Errorf("AssignedTask = %q, want test-task", updated.Status.AssignedTask)
+	}
+	// LastActivityAt must be refreshed on claim so the idle-aging logic
+	// in the sandbox controller doesn't fire mid-task.
+	if updated.Status.LastActivityAt == nil || !updated.Status.LastActivityAt.After(twoMinAgo.Time) {
+		t.Errorf("LastActivityAt should be refreshed on claim, got %v (was %v)", updated.Status.LastActivityAt, twoMinAgo)
+	}
+
+	var updatedTask factoryv1alpha1.Task
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-task", Namespace: "default"}, &updatedTask); err != nil {
+		t.Fatalf("fetching task: %v", err)
+	}
+	if updatedTask.Status.Phase != factoryv1alpha1.TaskPhaseRunning {
+		t.Errorf("task phase = %s, want Running", updatedTask.Status.Phase)
+	}
+	if updatedTask.Status.SandboxRef == nil || updatedTask.Status.SandboxRef.Name != "sb-idle" {
+		t.Errorf("expected sandbox ref sb-idle, got %v", updatedTask.Status.SandboxRef)
+	}
+}
+
+// TestTaskReconciler_PrefersReadyOverIdle asserts that when both Ready and
+// Idle sandboxes are available, Ready is preferred. Idle is the fallback.
+func TestTaskReconciler_PrefersReadyOverIdle(t *testing.T) {
+	scheme := newScheme()
+	task := newTask("test-task", "default", "test-pool")
+
+	idleSb := &factoryv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-idle", Namespace: "default"},
+		Spec:       factoryv1alpha1.SandboxSpec{PoolRef: factoryv1alpha1.LocalObjectReference{Name: "test-pool"}},
+		Status:     factoryv1alpha1.SandboxStatus{Phase: factoryv1alpha1.SandboxPhaseIdle},
+	}
+	readySb := &factoryv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-ready", Namespace: "default"},
+		Spec:       factoryv1alpha1.SandboxSpec{PoolRef: factoryv1alpha1.LocalObjectReference{Name: "test-pool"}},
+		Status:     factoryv1alpha1.SandboxStatus{Phase: factoryv1alpha1.SandboxPhaseReady},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(task, idleSb, readySb).
+		WithStatusSubresource(&factoryv1alpha1.Task{}, &factoryv1alpha1.Sandbox{}, &factoryv1alpha1.Session{}).
+		Build()
+
+	r := &TaskReconciler{Client: fakeClient, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-task", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updatedIdle factoryv1alpha1.Sandbox
+	_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "sb-idle", Namespace: "default"}, &updatedIdle)
+	if updatedIdle.Status.Phase != factoryv1alpha1.SandboxPhaseIdle {
+		t.Errorf("Idle sandbox should be untouched, got phase %s", updatedIdle.Status.Phase)
+	}
+
+	var updatedReady factoryv1alpha1.Sandbox
+	_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "sb-ready", Namespace: "default"}, &updatedReady)
+	if updatedReady.Status.Phase != factoryv1alpha1.SandboxPhaseAssigned {
+		t.Errorf("Ready sandbox should have been claimed, got phase %s", updatedReady.Status.Phase)
+	}
+}
+
 func TestTaskReconciler_RunningSessionCompleted(t *testing.T) {
 	scheme := newScheme()
 	now := metav1.Now()


### PR DESCRIPTION
## Summary

The Pool's `Idle` phase was meant to be the warm-pool sweet spot — keep a sandbox alive after a task so the next task gets sub-second startup instead of ~20s pod creation. But the implementation forgot the "reuse" half: tasks only claimed `Ready` sandboxes, leaving `Idle` ones to sit there blocking the Pool from creating replacements (Pool's min-replicas accounting counts `Idle` as non-terminating) until the idle timeout fired.

**Observed live:** a task submitted within 10 minutes of the previous task completing sat in Pending limbo for the full `idleTimeout` (10 min). Only manual `kubectl delete sandbox` unstuck it.

## The deadlock walk-through

1. Task A finishes → `releaseSandbox` sets sandbox to `Idle`.
2. Task B submitted → `findReadySandbox` filters by `Phase == Ready` only → returns nil.
3. Task controller requeues. Task B is stuck.
4. Pool controller sees `idle++ → totalNonTerminating == min` → no deficit → won't create a replacement.
5. Sandbox controller's `reconcileIdle` waits the full `idleTimeout` before terminating.
6. Net: Task B sits Pending for up to 10 minutes with a perfectly usable warm sandbox right there.

## Fix

- Rename `findReadySandbox` → `findAvailableSandbox` and match `Ready` **or** `Idle`. Ready preferred (so warmer sandboxes stay around for short-burst workloads); Idle as fallback.
- `claimSandbox` refreshes `LastActivityAt` on the claimed sandbox so `reconcileIdle` doesn't fire mid-task on a sandbox we just woke up.
- Switch the inner loop from "if X then return" to a small phase switch with an explicit no-op for the unclaimable phases (Creating/Assigned/Active/Terminating). Satisfies the `exhaustive` linter and reads better.

## Tradeoffs / what I considered

- **Option A (taken):** make tasks claim Idle. ~10 LoC, no CRD change, preserves existing semantics. Idle is now what it was always meant to be — a transient "warm and waiting" state.
- **Option B (rejected for now):** drop the `Idle` phase entirely; release back to `Ready` and let `LastActivityAt` drive aging. Cleaner state machine but requires CRD enum cleanup and touches more tests.
- **Option C (rejected):** explicit "wake" transition Idle → Ready before claim. Same effect as A with extra steps.

## Test plan

- [x] `TestTaskReconciler_PendingClaimsIdleSandbox` — pool with only an Idle sandbox; task transitions to Running, sandbox to Assigned, `LastActivityAt` refreshed.
- [x] `TestTaskReconciler_PrefersReadyOverIdle` — both phases present; Ready is claimed, Idle untouched.
- [x] Existing `TestTaskReconciler_PendingClaimsSandbox` (Ready path) still passes.
- [x] `make build` clean
- [x] `make lint` 0 issues
- [x] `go test -p 1 -race ./...` (full envtest + testharness) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)